### PR TITLE
Add mobile navigation menu to Header component

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,8 +1,25 @@
+import { useState, useCallback } from 'react';
 import { useWallet } from '../context/WalletContext';
 import { shortenAddress } from '../utils/formatting';
 
+const NAV_LINKS = [
+  { href: '#dashboard', label: 'Dashboard' },
+  { href: '#habits', label: 'My Habits' },
+  { href: '#pool', label: 'Pool' },
+  { href: 'https://github.com/Yusufolosun/AhhbitTracker#readme', label: 'Docs', external: true },
+];
+
 export function Header() {
   const { walletState, connect, disconnect } = useWallet();
+  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+
+  const toggleMenu = useCallback(() => {
+    setMobileMenuOpen((prev) => !prev);
+  }, []);
+
+  const closeMenu = useCallback(() => {
+    setMobileMenuOpen(false);
+  }, []);
 
   return (
     <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
@@ -15,23 +32,21 @@ export function Header() {
             </h1>
           </div>
 
-          {/* Navigation */}
+          {/* Desktop Navigation */}
           <nav className="hidden md:flex space-x-8">
-            <a href="#dashboard" className="text-gray-700 hover:text-primary-500 transition-colors">
-              Dashboard
-            </a>
-            <a href="#habits" className="text-gray-700 hover:text-primary-500 transition-colors">
-              My Habits
-            </a>
-            <a href="#pool" className="text-gray-700 hover:text-primary-500 transition-colors">
-              Pool
-            </a>
-            <a href="https://github.com/Yusufolosun/AhhbitTracker#readme" target="_blank" rel="noopener noreferrer" className="text-gray-700 hover:text-primary-500 transition-colors">
-              Docs
-            </a>
+            {NAV_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                className="text-gray-700 hover:text-primary-500 transition-colors"
+                {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+              >
+                {link.label}
+              </a>
+            ))}
           </nav>
 
-          {/* Wallet Connection */}
+          {/* Wallet + Mobile Toggle */}
           <div className="flex items-center space-x-4">
             {walletState.isConnected ? (
               <>
@@ -56,9 +71,58 @@ export function Header() {
                 Connect Wallet
               </button>
             )}
+
+            {/* Mobile menu toggle */}
+            <button
+              onClick={toggleMenu}
+              className="md:hidden p-2 rounded-md text-gray-600 hover:text-gray-900 hover:bg-gray-100 transition-colors"
+              aria-label={mobileMenuOpen ? 'Close menu' : 'Open menu'}
+              aria-expanded={mobileMenuOpen}
+            >
+              {mobileMenuOpen ? (
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              ) : (
+                <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h16M4 12h16M4 18h16" />
+                </svg>
+              )}
+            </button>
           </div>
         </div>
       </div>
+
+      {/* Mobile Navigation */}
+      {mobileMenuOpen && (
+        <nav className="md:hidden border-t border-gray-200 bg-white animate-fade-in">
+          <div className="px-4 py-3 space-y-1">
+            {NAV_LINKS.map((link) => (
+              <a
+                key={link.href}
+                href={link.href}
+                onClick={closeMenu}
+                className="block px-3 py-2 rounded-md text-base font-medium text-gray-700 hover:text-primary-500 hover:bg-gray-50 transition-colors"
+                {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+              >
+                {link.label}
+              </a>
+            ))}
+          </div>
+
+          {/* Mobile wallet info */}
+          {walletState.isConnected && (
+            <div className="px-4 py-3 border-t border-gray-100 sm:hidden">
+              <div className="flex items-center space-x-2">
+                <div className="w-2 h-2 bg-green-500 rounded-full"></div>
+                <span className="text-sm font-medium text-gray-700">
+                  {shortenAddress(walletState.address!)}
+                </span>
+              </div>
+            </div>
+          )}
+        </nav>
+      )}
     </header>
   );
 }


### PR DESCRIPTION
The header navigation was completely hidden on mobile viewports (below `md` breakpoint), leaving users with no way to navigate between sections on phones or small tablets.

### Changes

- Added a hamburger menu button that toggles a slide-down navigation panel on mobile
- Extracted navigation links into a shared constant array to avoid duplication between desktop and mobile views
- Mobile panel displays wallet address on small screens where the inline badge was also hidden
- Added `aria-label` and `aria-expanded` attributes to the toggle button for screen reader support

### Testing

Resize the browser below 768px width. The hamburger icon should appear, and clicking it should reveal the navigation links. Clicking a link or the X icon closes the menu.

Closes #16