### PR TITLE
fix: fetch and display wallet STX balance from network

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import { useState, useCallback } from 'react';
 import { useWallet } from '../context/WalletContext';
-import { shortenAddress } from '../utils/formatting';
+import { shortenAddress, formatSTX } from '../utils/formatting';
 
 const NAV_LINKS = [
   { href: '#dashboard', label: 'Dashboard' },
@@ -55,6 +55,11 @@ export function Header() {
                   <span className="text-sm font-medium text-gray-700">
                     {shortenAddress(walletState.address!)}
                   </span>
+                  {walletState.balance > 0 && (
+                    <span className="text-xs text-gray-500 border-l border-gray-300 pl-2">
+                      {formatSTX(walletState.balance)} STX
+                    </span>
+                  )}
                 </div>
                 <button
                   onClick={disconnect}

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -6,6 +6,7 @@ interface WalletContextType {
   walletState: WalletState;
   connect: () => Promise<void>;
   disconnect: () => void;
+  refreshBalance: () => Promise<void>;
   isLoading: boolean;
 }
 
@@ -31,6 +32,21 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
   });
   const [isLoading, setIsLoading] = useState(true);
 
+  const fetchAndSetBalance = async (address: string) => {
+    try {
+      const balance = await walletService.fetchBalance(address);
+      setWalletState((prev) => ({ ...prev, balance }));
+    } catch (error) {
+      console.error('Error fetching balance:', error);
+    }
+  };
+
+  const refreshBalance = async () => {
+    if (walletState.address) {
+      await fetchAndSetBalance(walletState.address);
+    }
+  };
+
   useEffect(() => {
     // Check if wallet is already connected on mount
     const checkConnection = async () => {
@@ -41,8 +57,11 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
           setWalletState({
             isConnected: true,
             address,
-            balance: 0, // Balance can be fetched separately if needed
+            balance: 0,
           });
+          if (address) {
+            fetchAndSetBalance(address);
+          }
         }
       } catch (error) {
         console.error('Error checking wallet connection:', error);
@@ -62,8 +81,11 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
         setWalletState({
           isConnected: true,
           address,
-          balance: 0, // Balance can be fetched separately if needed
+          balance: 0,
         });
+        if (address) {
+          fetchAndSetBalance(address);
+        }
         setIsLoading(false);
       });
     } catch (error) {
@@ -83,7 +105,7 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
   };
 
   return (
-    <WalletContext.Provider value={{ walletState, connect, disconnect, isLoading }}>
+    <WalletContext.Provider value={{ walletState, connect, disconnect, refreshBalance, isLoading }}>
       {children}
     </WalletContext.Provider>
   );

--- a/frontend/src/services/walletService.ts
+++ b/frontend/src/services/walletService.ts
@@ -1,9 +1,8 @@
 import { AppConfig, UserSession, showConnect } from '@stacks/connect';
-import { StacksMainnet } from '@stacks/network';
+import { NETWORK } from '../utils/constants';
 
 const appConfig = new AppConfig(['store_write', 'publish_data']);
 const userSession = new UserSession({ appConfig });
-const network = new StacksMainnet();
 
 export const walletService = {
   /**
@@ -56,5 +55,23 @@ export const walletService = {
   /**
    * Get network
    */
-  getNetwork: () => network,
+  getNetwork: () => NETWORK,
+
+  /**
+   * Fetch STX balance for an address from the Hiro API.
+   * Returns balance in microSTX.
+   */
+  fetchBalance: async (address: string): Promise<number> => {
+    const isDev = import.meta.env.DEV;
+    const baseUrl = isDev
+      ? `${window.location.origin}/api/stacks`
+      : 'https://api.mainnet.hiro.so';
+    const url = `${baseUrl}/v2/accounts/${address}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`Failed to fetch balance: ${response.status}`);
+    }
+    const data = await response.json();
+    return parseInt(data.balance, 10);
+  },
 };


### PR DESCRIPTION
The `WalletState.balance` field was always hardcoded to `0` — users had no idea how much STX they held before trying to stake.

### Changes

- **`walletService.ts`** — added `fetchBalance(address)` that hits the Hiro `/v2/accounts/{address}` endpoint and returns the balance in microSTX. Respects the Vite dev proxy to avoid CORS in development.
- **`WalletContext.tsx`** — calls `fetchBalance` after a successful sign-in check on mount and after a new wallet connection. Exposed `refreshBalance` on the context so other components can trigger a reload after transactions.
- **`Header.tsx`** — displays the formatted STX balance next to the shortened address when connected.

### Testing

Verified that `tsc --noEmit` passes with zero errors. The balance displays once the wallet connects to mainnet.

Closes #21
