### PR TITLE
feat: add confirmation dialog before withdraw and claim actions

### DIFF
--- a/frontend/src/components/ConfirmationDialog.tsx
+++ b/frontend/src/components/ConfirmationDialog.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useRef } from 'react';
+
+interface ConfirmationDialogProps {
+  open: boolean;
+  title: string;
+  children: React.ReactNode;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isLoading?: boolean;
+}
+
+export function ConfirmationDialog({
+  open,
+  title,
+  children,
+  confirmLabel = 'Confirm',
+  cancelLabel = 'Cancel',
+  onConfirm,
+  onCancel,
+  isLoading = false,
+}: ConfirmationDialogProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+
+  // Close on Escape key
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onCancel();
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, onCancel]);
+
+  // Trap focus inside the dialog
+  useEffect(() => {
+    if (open && dialogRef.current) {
+      dialogRef.current.focus();
+    }
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="confirmation-dialog-title"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50 transition-opacity"
+        onClick={onCancel}
+      />
+
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        tabIndex={-1}
+        className="relative bg-white rounded-xl shadow-xl max-w-md w-full mx-4 p-6 animate-fade-in"
+      >
+        <h2
+          id="confirmation-dialog-title"
+          className="text-lg font-semibold text-gray-900 mb-4"
+        >
+          {title}
+        </h2>
+
+        <div className="text-sm text-gray-600 mb-6">{children}</div>
+
+        <div className="flex justify-end space-x-3">
+          <button
+            onClick={onCancel}
+            disabled={isLoading}
+            className="px-4 py-2 text-sm font-medium text-gray-700 bg-gray-100 rounded-lg hover:bg-gray-200 transition-colors disabled:opacity-50"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={isLoading}
+            className="px-4 py-2 text-sm font-medium text-white bg-primary-500 rounded-lg hover:bg-primary-600 transition-colors disabled:opacity-50"
+          >
+            {isLoading ? 'Processing...' : confirmLabel}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Withdraw and claim are irreversible on-chain actions that cost gas. Clicking the buttons previously jumped straight to the wallet transaction popup with no summary.

### Changes

- **`ConfirmationDialog.tsx`** — new reusable modal component with backdrop click-to-dismiss, Escape key support, and ARIA attributes for accessibility.
- **`HabitCard.tsx`** — withdraw and claim buttons now open the dialog first. The dialog summarises:
  - **Withdraw**: habit name, stake amount, current streak
  - **Claim Bonus**: habit name, final streak

Both dialogs warn that the action is irreversible and incurs gas.

### Testing

`tsc --noEmit` passes. Existing HabitCard test still renders correctly since the dialog is hidden by default.

Closes #22
