### PR TITLE
fix: migrate frontend to Stacks SDK v7 to match root package

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -34,8 +34,8 @@
   "dependencies": {
     "@alloc/quick-lru": "^5.2.0",
     "@stacks/connect": "^7.0.0",
-    "@stacks/network": "^6.0.0",
-    "@stacks/transactions": "^6.0.0",
+    "@stacks/network": "^7.3.1",
+    "@stacks/transactions": "^7.2.0",
     "@tanstack/react-query": "^5.90.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/frontend/src/services/contractService.ts
+++ b/frontend/src/services/contractService.ts
@@ -3,12 +3,10 @@ import {
   uintCV,
   stringUtf8CV,
   principalCV,
-  callReadOnlyFunction,
+  fetchCallReadOnlyFunction,
   cvToJSON,
   PostConditionMode,
-  makeStandardSTXPostCondition,
-  FungibleConditionCode,
-  makeContractSTXPostCondition,
+  Pc,
 } from '@stacks/transactions';
 import { CONTRACT_ADDRESS, CONTRACT_NAME, NETWORK } from '../utils/constants';
 import { walletService } from './walletService';
@@ -26,11 +24,7 @@ export const contractService = {
 
     // Post-condition: User must transfer exactly the stake amount to the contract
     const postConditions = [
-      makeStandardSTXPostCondition(
-        userAddress,
-        FungibleConditionCode.Equal,
-        stakeAmount
-      ),
+      Pc.principal(userAddress).willSendEq(stakeAmount).ustx(),
     ];
 
     return new Promise((resolve, reject) => {
@@ -84,12 +78,7 @@ export const contractService = {
 
     // Post-condition: Contract must transfer at least 0 STX (actual amount determined by contract)
     const postConditions = [
-      makeContractSTXPostCondition(
-        CONTRACT_ADDRESS,
-        CONTRACT_NAME,
-        FungibleConditionCode.GreaterEqual,
-        0
-      ),
+      Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendGte(0).ustx(),
     ];
 
     return openContractCall({
@@ -118,12 +107,7 @@ export const contractService = {
 
     // Post-condition: Contract must transfer at least 0 STX (actual amount determined by contract)
     const postConditions = [
-      makeContractSTXPostCondition(
-        CONTRACT_ADDRESS,
-        CONTRACT_NAME,
-        FungibleConditionCode.GreaterEqual,
-        0
-      ),
+      Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendGte(0).ustx(),
     ];
 
     return openContractCall({
@@ -145,7 +129,7 @@ export const contractService = {
    * Get habit details
    */
   async getHabit(habitId: number): Promise<any> {
-    const result = await callReadOnlyFunction({
+    const result = await fetchCallReadOnlyFunction({
       contractAddress: CONTRACT_ADDRESS,
       contractName: CONTRACT_NAME,
       functionName: 'get-habit',
@@ -161,7 +145,7 @@ export const contractService = {
    * Get user habits
    */
   async getUserHabits(userAddress: string): Promise<any> {
-    const result = await callReadOnlyFunction({
+    const result = await fetchCallReadOnlyFunction({
       contractAddress: CONTRACT_ADDRESS,
       contractName: CONTRACT_NAME,
       functionName: 'get-user-habits',
@@ -177,7 +161,7 @@ export const contractService = {
    * Get habit streak
    */
   async getHabitStreak(habitId: number): Promise<number> {
-    const result = await callReadOnlyFunction({
+    const result = await fetchCallReadOnlyFunction({
       contractAddress: CONTRACT_ADDRESS,
       contractName: CONTRACT_NAME,
       functionName: 'get-habit-streak',
@@ -194,7 +178,7 @@ export const contractService = {
    * Get forfeited pool balance
    */
   async getPoolBalance(): Promise<number> {
-    const result = await callReadOnlyFunction({
+    const result = await fetchCallReadOnlyFunction({
       contractAddress: CONTRACT_ADDRESS,
       contractName: CONTRACT_NAME,
       functionName: 'get-pool-balance',
@@ -211,7 +195,7 @@ export const contractService = {
    * Get user stats
    */
   async getUserStats(userAddress: string): Promise<any> {
-    const result = await callReadOnlyFunction({
+    const result = await fetchCallReadOnlyFunction({
       contractAddress: CONTRACT_ADDRESS,
       contractName: CONTRACT_NAME,
       functionName: 'get-user-stats',

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -1,11 +1,11 @@
-import { StacksMainnet } from '@stacks/network';
+import { STACKS_MAINNET, createNetwork } from '@stacks/network';
 
 // Network Configuration
 // In development, use Vite proxy to avoid CORS issues with Hiro API
 const isDev = import.meta.env.DEV;
-export const NETWORK = new StacksMainnet({
-  url: isDev ? `${window.location.origin}/api/stacks` : 'https://api.mainnet.hiro.so',
-});
+export const NETWORK = isDev
+  ? createNetwork({ network: 'mainnet', client: { baseUrl: `${window.location.origin}/api/stacks` } })
+  : STACKS_MAINNET;
 
 // Contract Configuration
 export const CONTRACT_ADDRESS = 'SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193';


### PR DESCRIPTION
The root `package.json` depends on `@stacks/transactions@^7.2.0` and `@stacks/network@^7.3.1`, but the frontend was still pinned to v6 for both. Maintaining two major versions in the same repo causes confusion and makes future upgrades harder.

### Changes

- **`frontend/package.json`** — bumped `@stacks/network` from `^6.0.0` to `^7.3.1` and `@stacks/transactions` from `^6.0.0` to `^7.2.0`.
- **`constants.ts`** — replaced `new StacksMainnet({ url })` (removed in v7) with `STACKS_MAINNET` for production and `createNetwork()` with a custom `client.baseUrl` for the dev proxy.
- **`contractService.ts`** — replaced deprecated v6 APIs:
  - `callReadOnlyFunction` → `fetchCallReadOnlyFunction`
  - `makeStandardSTXPostCondition` / `makeContractSTXPostCondition` → `Pc` builder (`Pc.principal(...).willSendEq(...).ustx()`)

The `MULTI_WALLET_AUTOMATION.md` v6-to-v7 migration table was used as reference.

### Verification

- `npm install` completed cleanly (added 1 package, removed 7)
- `tsc --noEmit` passes with zero errors

Closes #25
