### PR TITLE
feat: support env vars for contract configuration

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,5 @@
+# Contract deployment address (defaults to mainnet)
+# VITE_CONTRACT_ADDRESS=SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193
+
+# Contract name (defaults to "habit-tracker")
+# VITE_CONTRACT_NAME=habit-tracker

--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -7,9 +7,11 @@ export const NETWORK = isDev
   ? createNetwork({ network: 'mainnet', client: { baseUrl: `${window.location.origin}/api/stacks` } })
   : STACKS_MAINNET;
 
-// Contract Configuration
-export const CONTRACT_ADDRESS = 'SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193';
-export const CONTRACT_NAME = 'habit-tracker';
+// Contract Configuration — override via VITE_CONTRACT_ADDRESS / VITE_CONTRACT_NAME
+export const CONTRACT_ADDRESS =
+  import.meta.env.VITE_CONTRACT_ADDRESS ?? 'SP1M46W6CVGAMH3ZJD3TKMY5KCY48HWAZK0DYG193';
+export const CONTRACT_NAME =
+  import.meta.env.VITE_CONTRACT_NAME ?? 'habit-tracker';
 
 // Contract Constants
 export const MIN_STAKE_AMOUNT = 100000; // 0.1 STX in microSTX


### PR DESCRIPTION
## Summary 
 
Allow the contract address and name to be configured via 
environment variables instead of hardcoding them. 
 
## Changes 
 
- Read `VITE_CONTRACT_ADDRESS` and `VITE_CONTRACT_NAME` from env 
- Fall back to existing mainnet values when unset 
- Add `frontend/.env.example` documenting available variables 
 
Closes #32 
