### PR TITLE
feat: add Open Graph and Twitter Card meta tags

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -7,6 +7,20 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Build better habits with blockchain accountability on Stacks" />
     <meta name="theme-color" content="#5546FF" />
+
+    <!-- Open Graph -->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="AhhbitTracker - On-Chain Habit Tracking" />
+    <meta property="og:description" content="Build better habits with blockchain accountability. Stake STX, check in daily, and earn rewards on Stacks." />
+    <meta property="og:image" content="/og-preview.png" />
+    <meta property="og:url" content="https://ahhbittracker.xyz" />
+
+    <!-- Twitter Card -->
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="AhhbitTracker - On-Chain Habit Tracking" />
+    <meta name="twitter:description" content="Build better habits with blockchain accountability. Stake STX, check in daily, and earn rewards on Stacks." />
+    <meta name="twitter:image" content="/og-preview.png" />
+
     <title>AhhbitTracker - On-Chain Habit Tracking</title>
   </head>
   <body>


### PR DESCRIPTION
## Summary 
 
Add Open Graph and Twitter Card meta tags so link previews 
render correctly on social platforms. 
 
## Changes 
 
- Add `og:type`, `og:title`, `og:description`, `og:image`, `og:url` 
- Add `twitter:card`, `twitter:title`, `twitter:description`, `twitter:image` 
 
Closes #26 
