### PR TITLE
fix: enforce meaningful post-conditions on withdraw and claim

### DIFF
--- a/frontend/src/components/HabitCard.tsx
+++ b/frontend/src/components/HabitCard.tsx
@@ -27,7 +27,7 @@ export function HabitCard({ habit }: HabitCardProps) {
 
   const executeConfirmedAction = () => {
     if (confirmAction === 'withdraw') {
-      withdrawStake(habit.habitId);
+      withdrawStake({ habitId: habit.habitId, stakeAmount: habit.stakeAmount });
     } else if (confirmAction === 'claim') {
       claimBonus(habit.habitId);
     }

--- a/frontend/src/hooks/useHabits.ts
+++ b/frontend/src/hooks/useHabits.ts
@@ -126,7 +126,8 @@ export const useHabits = () => {
 
   // Withdraw stake mutation
   const withdrawStakeMutation = useMutation({
-    mutationFn: (habitId: number) => contractService.withdrawStake(habitId),
+    mutationFn: ({ habitId, stakeAmount }: { habitId: number; stakeAmount: number }) =>
+      contractService.withdrawStake(habitId, stakeAmount),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['habits', walletState.address] });
       queryClient.invalidateQueries({ queryKey: ['userStats', walletState.address] });

--- a/frontend/src/services/contractService.ts
+++ b/frontend/src/services/contractService.ts
@@ -70,15 +70,15 @@ export const contractService = {
   /**
    * Withdraw stake
    */
-  async withdrawStake(habitId: number): Promise<void> {
+  async withdrawStake(habitId: number, stakeAmount: number): Promise<void> {
     const userAddress = walletService.getAddress();
     if (!userAddress) {
       throw new Error('Wallet not connected');
     }
 
-    // Post-condition: Contract must transfer at least 0 STX (actual amount determined by contract)
+    // Post-condition: Contract must transfer exactly the staked amount back to the user
     const postConditions = [
-      Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendGte(0).ustx(),
+      Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendEq(stakeAmount).ustx(),
     ];
 
     return openContractCall({
@@ -105,9 +105,9 @@ export const contractService = {
       throw new Error('Wallet not connected');
     }
 
-    // Post-condition: Contract must transfer at least 0 STX (actual amount determined by contract)
+    // Post-condition: Contract must transfer at least 1 microSTX from the pool
     const postConditions = [
-      Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendGte(0).ustx(),
+      Pc.principal(`${CONTRACT_ADDRESS}.${CONTRACT_NAME}`).willSendGte(1).ustx(),
     ];
 
     return openContractCall({


### PR DESCRIPTION
## Summary 
 
Strengthen post-conditions so the wallet actually guards 
against unexpected token transfers. 
 
## Changes 
 
- `withdrawStake` now accepts `stakeAmount` and uses `willSendEq` 
- `claimBonus` uses `willSendGte(1)` instead of `willSendGte(0)` 
- Thread `stakeAmount` through `useHabits` mutation and `HabitCard` 
 
Closes #27 
