### PR TITLE
fix: prevent repeated claim-bonus from draining pool

### DIFF
--- a/frontend/src/utils/constants.ts
+++ b/frontend/src/utils/constants.ts
@@ -32,6 +32,7 @@ export const ERROR_CODES: Record<number, string> = {
   108: 'Habit already completed',
   109: 'Insufficient pool balance',
   110: 'Transfer failed',
+  111: 'Bonus already claimed for this habit',
 };
 
 // UI Constants


### PR DESCRIPTION
Prevent repeated claim-bonus calls from draining the pool. Closes #34