### PR TITLE
feat: add hash-based client-side routing

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,6 +14,7 @@ import { PoolDisplay } from './components/PoolDisplay';
 import { TransactionTracker } from './components/TransactionTracker';
 import { ToastContainer } from './components/ToastContainer';
 import { useHabits } from './hooks/useHabits';
+import { useHashRoute } from './hooks/useHashRoute';
 import './styles/global.css';
 
 // Create a react-query client
@@ -30,17 +31,18 @@ const queryClient = new QueryClient({
 function AppContent() {
   const { walletState } = useWallet();
   const { habits, isLoadingHabits } = useHabits();
+  const { route } = useHashRoute();
 
   if (!walletState.isConnected) {
     return (
-      <div className="min-h-screen flex items-center justify-center bg-gray-50 px-4">
+      <div className="min-h-screen flex items-center justify-center bg-gray-50 dark:bg-gray-900 px-4">
         <WalletConnect />
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen flex flex-col bg-gray-50">
+    <div className="min-h-screen flex flex-col bg-gray-50 dark:bg-gray-900">
       {/* Skip to content link for keyboard/screen-reader users */}
       <a
         href="#main-content"
@@ -53,26 +55,31 @@ function AppContent() {
 
       <main id="main-content" className="flex-1 max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8 py-8">
         <div className="space-y-8">
-          {/* Dashboard */}
-          <section id="dashboard" className="scroll-mt-20">
-            <Dashboard habits={habits} />
-          </section>
+          {/* Route-based rendering */}
+          {route === 'dashboard' && (
+            <section id="dashboard">
+              <Dashboard habits={habits} />
+            </section>
+          )}
 
-          {/* Pool Display */}
-          <section id="pool" className="scroll-mt-20">
-            <PoolDisplay />
-          </section>
+          {route === 'pool' && (
+            <section id="pool">
+              <PoolDisplay />
+            </section>
+          )}
 
-          {/* Create Habit Form */}
-          <section id="create-habit" className="scroll-mt-20">
-            <HabitForm />
-          </section>
+          {route === 'create-habit' && (
+            <section id="create-habit">
+              <HabitForm />
+            </section>
+          )}
 
-          {/* Habit List */}
-          <section id="habits" className="scroll-mt-20">
-            <h2 className="text-2xl font-bold text-gray-900 mb-6">My Habits</h2>
-            <HabitList habits={habits} loading={isLoadingHabits} />
-          </section>
+          {route === 'habits' && (
+            <section id="habits">
+              <h2 className="text-2xl font-bold text-gray-900 dark:text-gray-100 mb-6">My Habits</h2>
+              <HabitList habits={habits} loading={isLoadingHabits} />
+            </section>
+          )}
         </div>
       </main>
 

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,16 +2,19 @@ import { useState, useCallback } from 'react';
 import { useWallet } from '../context/WalletContext';
 import { shortenAddress, formatSTX } from '../utils/formatting';
 import { ThemeToggle } from './ThemeToggle';
+import { useHashRoute } from '../hooks/useHashRoute';
 
 const NAV_LINKS = [
   { href: '#dashboard', label: 'Dashboard' },
   { href: '#habits', label: 'My Habits' },
+  { href: '#create-habit', label: 'New Habit' },
   { href: '#pool', label: 'Pool' },
   { href: 'https://github.com/Yusufolosun/AhhbitTracker#readme', label: 'Docs', external: true },
 ];
 
 export function Header() {
   const { walletState, connect, disconnect } = useWallet();
+  const { route } = useHashRoute();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
   const toggleMenu = useCallback(() => {
@@ -35,16 +38,23 @@ export function Header() {
 
           {/* Desktop Navigation */}
           <nav className="hidden md:flex space-x-8">
-            {NAV_LINKS.map((link) => (
-              <a
-                key={link.href}
-                href={link.href}
-                className="text-gray-700 hover:text-primary-500 transition-colors"
-                {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-              >
-                {link.label}
-              </a>
-            ))}
+            {NAV_LINKS.map((link) => {
+              const isActive = !link.external && link.href === `#${route}`;
+              return (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  className={`transition-colors ${
+                    isActive
+                      ? 'text-primary-500 font-semibold'
+                      : 'text-gray-700 dark:text-gray-300 hover:text-primary-500'
+                  }`}
+                  {...(link.external ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+                >
+                  {link.label}
+                </a>
+              );
+            })}
           </nav>
 
           {/* Wallet + Theme + Mobile Toggle */}

--- a/frontend/src/hooks/useHashRoute.ts
+++ b/frontend/src/hooks/useHashRoute.ts
@@ -1,0 +1,29 @@
+import { useState, useEffect, useCallback } from 'react';
+
+const ROUTES = ['dashboard', 'pool', 'create-habit', 'habits'] as const;
+export type Route = (typeof ROUTES)[number];
+
+function parseHash(): Route {
+  const raw = window.location.hash.replace('#', '');
+  return (ROUTES as readonly string[]).includes(raw) ? (raw as Route) : 'dashboard';
+}
+
+/**
+ * Lightweight hash-based router.
+ * Listens to `hashchange` and returns the current route + a navigate helper.
+ */
+export function useHashRoute() {
+  const [route, setRoute] = useState<Route>(parseHash);
+
+  useEffect(() => {
+    const onHashChange = () => setRoute(parseHash());
+    window.addEventListener('hashchange', onHashChange);
+    return () => window.removeEventListener('hashchange', onHashChange);
+  }, []);
+
+  const navigate = useCallback((target: Route) => {
+    window.location.hash = target;
+  }, []);
+
+  return { route, navigate };
+}


### PR DESCRIPTION
Replace scroll-anchor layout with hash-based routing so only the active section renders. Closes #31