### PR TITLE
Fix wallet balance flashing 0 STX on connect

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -13,7 +13,7 @@ const NAV_LINKS = [
 ];
 
 export function Header() {
-  const { walletState, connect, disconnect } = useWallet();
+  const { walletState, connect, disconnect, isBalanceLoading } = useWallet();
   const { route } = useHashRoute();
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
 
@@ -78,7 +78,11 @@ export function Header() {
                   >
                     {shortenAddress(walletState.address!)}
                   </a>
-                  {walletState.balance > 0 && (
+                  {isBalanceLoading ? (
+                    <span className="text-xs text-surface-400 border-l border-surface-300 dark:border-surface-600 pl-2 animate-pulse">
+                      Loading…
+                    </span>
+                  ) : walletState.balance > 0 && (
                     <span className="text-xs text-surface-500 border-l border-surface-300 dark:border-surface-600 pl-2">
                       {formatSTX(walletState.balance)} STX
                     </span>

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -8,6 +8,7 @@ interface WalletContextType {
   disconnect: () => void;
   refreshBalance: () => Promise<void>;
   isLoading: boolean;
+  isBalanceLoading: boolean;
 }
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
@@ -31,13 +32,17 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
     balance: 0,
   });
   const [isLoading, setIsLoading] = useState(true);
+  const [isBalanceLoading, setIsBalanceLoading] = useState(false);
 
   const fetchAndSetBalance = async (address: string) => {
+    setIsBalanceLoading(true);
     try {
       const balance = await walletService.fetchBalance(address);
       setWalletState((prev) => ({ ...prev, balance }));
     } catch (error) {
       console.error('Error fetching balance:', error);
+    } finally {
+      setIsBalanceLoading(false);
     }
   };
 
@@ -60,7 +65,7 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
             balance: 0,
           });
           if (address) {
-            fetchAndSetBalance(address);
+            await fetchAndSetBalance(address);
           }
         }
       } catch (error) {
@@ -76,7 +81,7 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
   const connect = async () => {
     setIsLoading(true);
     try {
-      walletService.connect(() => {
+      walletService.connect(async () => {
         const address = walletService.getAddress();
         setWalletState({
           isConnected: true,
@@ -84,7 +89,7 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
           balance: 0,
         });
         if (address) {
-          fetchAndSetBalance(address);
+          await fetchAndSetBalance(address);
         }
         setIsLoading(false);
       });
@@ -105,7 +110,7 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
   };
 
   return (
-    <WalletContext.Provider value={{ walletState, connect, disconnect, refreshBalance, isLoading }}>
+    <WalletContext.Provider value={{ walletState, connect, disconnect, refreshBalance, isLoading, isBalanceLoading }}>
       {children}
     </WalletContext.Provider>
   );


### PR DESCRIPTION
## Summary

Fixes a race condition in WalletProvider where the balance briefly showed 0 STX after connecting or on page reload. The root cause was that `fetchAndSetBalance` was fire-and-forget — the loading state cleared before the balance API call resolved.

## What changed

**`WalletContext.tsx`**
- Added `isBalanceLoading` state so consumers can distinguish between "balance is 0" and "balance hasn't loaded yet"
- `checkConnection` (mount effect): now `await`s the balance fetch before setting `isLoading = false`
- `connect` callback: made async so balance resolves before the loading spinner disappears
- `fetchAndSetBalance`: sets `isBalanceLoading` around the fetch call

**`Header.tsx`**
- Reads `isBalanceLoading` from context
- Shows a "Loading…" placeholder while balance is being fetched instead of hiding the balance section entirely

## Testing

1. Disconnect wallet, reconnect — balance should never flash 0
2. Hard refresh while connected — balance loads cleanly without flicker
3. If balance API fails, the loading indicator clears and falls back to showing nothing (same as before)

Closes #73