### PR TITLE
Add transaction confirmation polling to TransactionTracker

### DIFF
--- a/frontend/src/components/TransactionTracker.tsx
+++ b/frontend/src/components/TransactionTracker.tsx
@@ -1,4 +1,5 @@
 import { useTransactions } from '../context/TransactionContext';
+import type { TrackedTransaction } from '../context/TransactionContext';
 
 export function TransactionTracker() {
   const { transactions, dismissTransaction, getExplorerUrl } = useTransactions();
@@ -12,12 +13,12 @@ export function TransactionTracker() {
       {transactions.map((tx) => (
         <div
           key={tx.txId}
-          className="bg-white dark:bg-surface-800 border border-surface-200 dark:border-surface-700 rounded-lg shadow-lg p-4 animate-slide-in"
+          className={`bg-white dark:bg-surface-800 border rounded-lg shadow-lg p-4 animate-slide-in ${statusBorderClass(tx.status)}`}
         >
           <div className="flex items-start justify-between">
             <div className="flex-1 min-w-0">
               <div className="flex items-center space-x-2 mb-1">
-                <div className="w-2 h-2 bg-primary-400 rounded-full animate-pulse"></div>
+                <StatusDot status={tx.status} />
                 <p className="text-sm font-medium text-surface-900 dark:text-white truncate">
                   {formatFunctionName(tx.functionName)}
                 </p>
@@ -38,9 +39,7 @@ export function TransactionTracker() {
           </div>
 
           <div className="mt-2 flex items-center justify-between">
-            <span className="text-xs text-primary-600 dark:text-primary-400 font-medium">
-              Submitted — waiting for confirmation
-            </span>
+            <StatusLabel status={tx.status} />
             <a
               href={getExplorerUrl(tx.txId)}
               target="_blank"
@@ -54,6 +53,45 @@ export function TransactionTracker() {
       ))}
     </div>
   );
+}
+
+function StatusDot({ status }: { status: TrackedTransaction['status'] }) {
+  const colorClass =
+    status === 'confirmed'
+      ? 'bg-emerald-500'
+      : status === 'failed'
+        ? 'bg-red-500'
+        : 'bg-primary-400 animate-pulse';
+
+  return <div className={`w-2 h-2 rounded-full ${colorClass}`} />;
+}
+
+function StatusLabel({ status }: { status: TrackedTransaction['status'] }) {
+  if (status === 'confirmed') {
+    return (
+      <span className="text-xs text-emerald-600 dark:text-emerald-400 font-medium">
+        Confirmed
+      </span>
+    );
+  }
+  if (status === 'failed') {
+    return (
+      <span className="text-xs text-red-600 dark:text-red-400 font-medium">
+        Failed
+      </span>
+    );
+  }
+  return (
+    <span className="text-xs text-primary-600 dark:text-primary-400 font-medium">
+      Submitted — waiting for confirmation
+    </span>
+  );
+}
+
+function statusBorderClass(status: TrackedTransaction['status']): string {
+  if (status === 'confirmed') return 'border-emerald-200 dark:border-emerald-800';
+  if (status === 'failed') return 'border-red-200 dark:border-red-800';
+  return 'border-surface-200 dark:border-surface-700';
 }
 
 function shortenTxId(txId: string): string {

--- a/frontend/src/context/TransactionContext.tsx
+++ b/frontend/src/context/TransactionContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, useCallback, ReactNode } from 'react';
+import React, { createContext, useContext, useState, useCallback, useEffect, useRef, ReactNode } from 'react';
 import { EXPLORER_TX_URL } from '../utils/constants';
 
 export interface TrackedTransaction {
@@ -30,8 +30,52 @@ interface TransactionProviderProps {
   children: ReactNode;
 }
 
+const TX_POLL_INTERVAL = 15_000; // 15 seconds
+const TX_POLL_TIMEOUT = 30 * 60_000; // stop polling after 30 minutes
+
+/**
+ * Fetch transaction status from the Hiro API.
+ * Returns 'confirmed', 'failed', or 'pending'.
+ */
+async function fetchTxStatus(txId: string): Promise<'confirmed' | 'failed' | 'pending'> {
+  const isDev = typeof import.meta !== 'undefined' && import.meta.env?.DEV;
+  const baseUrl = isDev
+    ? `${typeof window !== 'undefined' ? window.location.origin : ''}/api/stacks`
+    : 'https://api.mainnet.hiro.so';
+
+  const cleanTxId = txId.startsWith('0x') ? txId : `0x${txId}`;
+  const url = `${baseUrl}/extended/v1/tx/${cleanTxId}`;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
+
+  try {
+    const response = await fetch(url, { signal: controller.signal });
+    clearTimeout(timeout);
+
+    if (!response.ok) {
+      // 404 usually means the tx hasn't been picked up yet — still pending
+      if (response.status === 404) return 'pending';
+      return 'pending';
+    }
+
+    const data = await response.json();
+    const status: string = data.tx_status;
+
+    if (status === 'success') return 'confirmed';
+    if (status === 'pending') return 'pending';
+    // Any abort or drop status counts as failed
+    if (status.startsWith('abort_') || status.startsWith('dropped_')) return 'failed';
+    return 'pending';
+  } catch {
+    // Network error or timeout — assume still pending
+    return 'pending';
+  }
+}
+
 export const TransactionProvider: React.FC<TransactionProviderProps> = ({ children }) => {
   const [transactions, setTransactions] = useState<TrackedTransaction[]>([]);
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
   const addTransaction = useCallback((txId: string, functionName: string) => {
     setTransactions((prev) => [
@@ -56,6 +100,56 @@ export const TransactionProvider: React.FC<TransactionProviderProps> = ({ childr
   const getExplorerUrl = useCallback((txId: string) => {
     return `${EXPLORER_TX_URL}${txId}?chain=mainnet`;
   }, []);
+
+  // Poll pending transactions for confirmation
+  useEffect(() => {
+    const pollPendingTransactions = async () => {
+      const now = Date.now();
+
+      const pendingTxs = transactions.filter(
+        (tx) => tx.status === 'pending' && now - tx.timestamp < TX_POLL_TIMEOUT
+      );
+
+      if (pendingTxs.length === 0) return;
+
+      const updates: { txId: string; status: 'confirmed' | 'failed' }[] = [];
+
+      await Promise.all(
+        pendingTxs.map(async (tx) => {
+          const status = await fetchTxStatus(tx.txId);
+          if (status !== 'pending') {
+            updates.push({ txId: tx.txId, status });
+          }
+        })
+      );
+
+      if (updates.length > 0) {
+        setTransactions((prev) =>
+          prev.map((tx) => {
+            const update = updates.find((u) => u.txId === tx.txId);
+            return update ? { ...tx, status: update.status } : tx;
+          })
+        );
+      }
+    };
+
+    // Only set up polling if there are pending transactions
+    const hasPending = transactions.some((tx) => tx.status === 'pending');
+
+    if (hasPending) {
+      // Poll immediately on first pending tx
+      pollPendingTransactions();
+
+      intervalRef.current = setInterval(pollPendingTransactions, TX_POLL_INTERVAL);
+    }
+
+    return () => {
+      if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+  }, [transactions.filter((tx) => tx.status === 'pending').map((tx) => tx.txId).join(',')]);
 
   return (
     <TransactionContext.Provider


### PR DESCRIPTION
## Problem

After submitting a transaction, the tracker notification was stuck showing "Submitted — waiting for confirmation" indefinitely. The `TrackedTransaction.status` field supported `'confirmed'` and `'failed'` but nothing ever updated it from `'pending'`.

Users had to open the Stacks Explorer manually to check if their transaction went through, which led to confusion and occasional duplicate submissions.

## Solution

Added a polling mechanism in `TransactionContext` that checks the Hiro API for the status of each pending transaction:

- Polls `/extended/v1/tx/{txId}` every 15 seconds for any transaction still in pending state
- Updates to **confirmed** when `tx_status === 'success'`
- Updates to **failed** on any `abort_*` or `dropped_*` status
- Stops polling automatically after 30 minutes as a safety net
- Each API call has a 10-second timeout via AbortController so a slow API doesn't block anything
- Polling only runs when there are pending transactions — no unnecessary network calls

## UI updates in TransactionTracker

- **Pending**: pulsing blue dot + original "waiting for confirmation" text
- **Confirmed**: solid green dot + "Confirmed" label + green border accent
- **Failed**: solid red dot + "Failed" label + red border accent
- Explorer link stays visible in all states

## Testing

1. Submit any transaction (create habit, check-in, etc.)
2. Watch the notification — should update to Confirmed after the tx is mined (~10 min on mainnet)
3. If a transaction fails (e.g., abort by post-condition), it should show Failed with a red indicator

Closes #74