### PR TITLE
fix: remove unsafe-inline from script-src CSP header

### DIFF
--- a/frontend/vercel.json
+++ b/frontend/vercel.json
@@ -14,7 +14,7 @@
         { "key": "X-XSS-Protection", "value": "1; mode=block" },
         { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
         { "key": "Permissions-Policy", "value": "camera=(), microphone=(), geolocation=()" },
-        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.hiro.so https://api.mainnet.hiro.so https://stacks-node-api.mainnet.stacks.co https://explorer.hiro.so; frame-ancestors 'none';" }
+        { "key": "Content-Security-Policy", "value": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self' https://api.hiro.so https://api.mainnet.hiro.so https://stacks-node-api.mainnet.stacks.co https://explorer.hiro.so; frame-ancestors 'none';" }
       ]
     },
     {

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
   },
   build: {
     outDir: 'dist',
+    modulePreload: { polyfill: false },
   },
   test: {
     environment: 'jsdom',


### PR DESCRIPTION
## Problem

The `Content-Security-Policy` header in `vercel.json` included `script-src 'self' 'unsafe-inline'`. This defeats XSS protection since any injected inline script would execute.

## Fix

1. **Removed `'unsafe-inline'` from `script-src`** — Vite bundles all JS into external files, so no inline scripts are needed
2. **Disabled Vite module preload polyfill** (`modulePreload: { polyfill: false }`) — this polyfill is injected as an inline script by default, but all modern browsers support native `<link rel="modulepreload">` natively
3. **Retained `'unsafe-inline'` in `style-src`** — required by Tailwind CSS

## Verification

- Production build produces zero inline scripts (verified by inspecting `dist/index.html`)
- All 44 frontend tests pass
- Build completes successfully

Closes #75