### PR TITLE
feat: add maximum stake limit of 100 STX

### DIFF
--- a/contracts/habit-tracker.clar
+++ b/contracts/habit-tracker.clar
@@ -19,6 +19,10 @@
 ;; Minimum: 0.1 STX = 100,000 microSTX
 (define-constant MIN-STAKE-AMOUNT u100000)
 
+;; Maximum stake allowed (in microSTX)
+;; 100 STX = 100,000,000 microSTX
+(define-constant MAX-STAKE-AMOUNT u100000000)
+
 ;; Maximum habit name length
 (define-constant MAX-HABIT-NAME-LENGTH u50)
 
@@ -49,6 +53,7 @@
 (define-constant ERR-TRANSFER-FAILED (err u110))
 (define-constant ERR-BONUS-ALREADY-CLAIMED (err u111))
 (define-constant ERR-HABIT-LIMIT-REACHED (err u112))
+(define-constant ERR-STAKE-TOO-HIGH (err u113))
 
 ;; ============================================
 ;; DATA STRUCTURES
@@ -150,6 +155,7 @@
     )
     ;; Validate stake amount
     (asserts! (>= stake-amount MIN-STAKE-AMOUNT) ERR-INVALID-STAKE-AMOUNT)
+    (asserts! (<= stake-amount MAX-STAKE-AMOUNT) ERR-STAKE-TOO-HIGH)
     
     ;; Validate habit name
     (asserts! (is-valid-habit-name name) ERR-INVALID-HABIT-NAME)

--- a/tests/habit-tracker.test.ts
+++ b/tests/habit-tracker.test.ts
@@ -93,6 +93,20 @@ describe("AhhbitTracker Contract", () => {
       expect(result.result).toBeOk(Cl.uint(1));
     });
 
+    it("should reject stake above maximum (100 STX)", () => {
+      const aboveMax = 100_000_001; // 100 STX + 1 microSTX
+      const result = createHabit(user1, VALID_HABIT_NAME, aboveMax);
+
+      expect(result.result).toBeErr(Cl.uint(113)); // ERR-STAKE-TOO-HIGH
+    });
+
+    it("should accept stake at exactly maximum (100 STX)", () => {
+      const exactMax = 100_000_000; // 100 STX
+      const result = createHabit(user1, VALID_HABIT_NAME, exactMax);
+
+      expect(result.result).toBeOk(Cl.uint(1));
+    });
+
     it("should reject empty habit name", () => {
       const result = createHabit(user1, "", MIN_STAKE);
 


### PR DESCRIPTION
## Problem

The contract defines `MIN-STAKE-AMOUNT` (0.1 STX) but has no upper bound. A user could stake thousands of STX on a single habit — a typo (100 STX instead of 1 STX) has no safety net, and a large forfeiture skews the bonus pool.

## Fix

1. **Added `MAX-STAKE-AMOUNT u100000000`** (100 STX) constant
2. **Added `ERR-STAKE-TOO-HIGH (err u113)`** error code
3. **Added validation** in `create-habit`: `(asserts! (<= stake-amount MAX-STAKE-AMOUNT) ERR-STAKE-TOO-HIGH)`

## Tests

- `should reject stake above maximum (100 STX)` — 100,000,001 microSTX returns error 113
- `should accept stake at exactly maximum (100 STX)` — boundary passes

All 224 tests pass (36 contract tests).

Closes #84