### PR TITLE
fix: fair bonus distribution — 1% pool share capped at 1 STX

### DIFF
--- a/contracts/habit-tracker.clar
+++ b/contracts/habit-tracker.clar
@@ -33,6 +33,10 @@
 ;; Minimum streak required for withdrawal
 (define-constant MIN-STREAK-FOR-WITHDRAWAL u7)
 
+;; Bonus distribution: 1% of pool per claim, capped at 1 STX
+(define-constant BONUS-DIVISOR u100)
+(define-constant MAX-BONUS-AMOUNT u1000000)
+
 ;; Contract owner
 (define-constant CONTRACT-OWNER tx-sender)
 
@@ -351,8 +355,9 @@
       (caller tx-sender)
       (habit (unwrap! (map-get? habits { habit-id: habit-id }) ERR-HABIT-NOT-FOUND))
       (pool-balance (var-get forfeited-pool-balance))
-      ;; Simple bonus calculation: 10% of pool per completed habit
-      (bonus-amount (/ pool-balance u10))
+      ;; Bonus: 1% of pool, capped at MAX-BONUS-AMOUNT (1 STX)
+      (raw-bonus (/ pool-balance BONUS-DIVISOR))
+      (bonus-amount (if (<= raw-bonus MAX-BONUS-AMOUNT) raw-bonus MAX-BONUS-AMOUNT))
     )
     ;; Verify caller is habit owner
     (asserts! (is-eq caller (get owner habit)) ERR-NOT-HABIT-OWNER)
@@ -363,7 +368,8 @@
     ;; Verify bonus has not already been claimed for this habit
     (asserts! (not (get bonus-claimed habit)) ERR-BONUS-ALREADY-CLAIMED)
     
-    ;; Verify pool has sufficient balance
+    ;; Verify pool has sufficient balance and bonus is non-zero
+    (asserts! (> bonus-amount u0) ERR-POOL-INSUFFICIENT-BALANCE)
     (asserts! (>= pool-balance bonus-amount) ERR-POOL-INSUFFICIENT-BALANCE)
     
     ;; Transfer bonus from pool to user

--- a/tests/habit-tracker.test.ts
+++ b/tests/habit-tracker.test.ts
@@ -9,6 +9,7 @@ const user3 = accounts.get("wallet_3")!;
 
 // Test Helpers
 const MIN_STAKE = 100000; // 0.1 STX in microSTX
+const MAX_STAKE_AMOUNT = 100_000_000; // 100 STX in microSTX
 const VALID_HABIT_NAME = "Daily Exercise";
 const MAX_NAME_LENGTH = 50;
 
@@ -396,8 +397,70 @@ describe("AhhbitTracker Contract", () => {
 
       // 4. Claim bonus
       const result = simnet.callPublicFn("habit-tracker", "claim-bonus", [Cl.uint(id1)], user1);
-      // Pool had MIN_STAKE * 10. 10% is MIN_STAKE
-      expect(result.result).toEqual(Cl.ok(Cl.uint(MIN_STAKE)));
+      // Pool had MIN_STAKE * 10 (1 STX). 1% = MIN_STAKE / 10 = 10000
+      expect(result.result).toEqual(Cl.ok(Cl.uint(MIN_STAKE / 10)));
+    });
+
+    it("should distribute nearly equal bonuses to consecutive claimants", () => {
+      // Fund the pool: slash a 1 STX habit
+      const failHabit = createHabit(user3, "Will fail", MIN_STAKE * 10);
+      const failId = Number((failHabit.result as any).value.value);
+      checkIn(user3, failId);
+      simnet.mineEmptyBlocks(150);
+      simnet.callPublicFn("habit-tracker", "slash-habit", [Cl.uint(failId)], user3);
+      // Pool = 1,000,000 microSTX (1 STX)
+
+      // User1 completes a habit
+      const h1 = createHabit(user1, "Habit A", MIN_STAKE);
+      const id1 = Number((h1.result as any).value.value);
+      for (let i = 0; i < 7; i++) { checkIn(user1, id1); simnet.mineEmptyBlocks(10); }
+      withdrawStake(user1, id1);
+
+      // User2 completes a habit
+      const h2 = createHabit(user2, "Habit B", MIN_STAKE);
+      const id2 = Number((h2.result as any).value.value);
+      for (let i = 0; i < 7; i++) { checkIn(user2, id2); simnet.mineEmptyBlocks(10); }
+      withdrawStake(user2, id2);
+
+      // Both claim — bonuses should be within ~1% of each other
+      const claim1 = simnet.callPublicFn("habit-tracker", "claim-bonus", [Cl.uint(id1)], user1);
+      const claim2 = simnet.callPublicFn("habit-tracker", "claim-bonus", [Cl.uint(id2)], user2);
+
+      const bonus1 = Number((claim1.result as any).value.value);
+      const bonus2 = Number((claim2.result as any).value.value);
+
+      // With 1% per claim, the spread between first and second is ~1%
+      // bonus1 = pool / 100, bonus2 = (pool - bonus1) / 100
+      expect(bonus1).toBeGreaterThan(0);
+      expect(bonus2).toBeGreaterThan(0);
+      // Difference should be less than 2% (much better than old 10%)
+      expect((bonus1 - bonus2) / bonus1).toBeLessThan(0.02);
+    });
+
+    it("should cap bonus at MAX-BONUS-AMOUNT (1 STX)", () => {
+      // Fund pool with two large slashed stakes to exceed 100 STX
+      const fail1 = createHabit(user2, "Big stake 1", MAX_STAKE_AMOUNT);
+      const fid1 = Number((fail1.result as any).value.value);
+      checkIn(user2, fid1);
+      simnet.mineEmptyBlocks(150);
+      simnet.callPublicFn("habit-tracker", "slash-habit", [Cl.uint(fid1)], user1);
+
+      const fail2 = createHabit(user3, "Big stake 2", MAX_STAKE_AMOUNT);
+      const fid2 = Number((fail2.result as any).value.value);
+      checkIn(user3, fid2);
+      simnet.mineEmptyBlocks(150);
+      simnet.callPublicFn("habit-tracker", "slash-habit", [Cl.uint(fid2)], user1);
+      // Pool = 200 STX. 1% = 2 STX > MAX-BONUS-AMOUNT (1 STX)
+
+      // User1 completes a habit and claims
+      const h1 = createHabit(user1, "Capped habit", MIN_STAKE);
+      const cid = Number((h1.result as any).value.value);
+      for (let i = 0; i < 7; i++) { checkIn(user1, cid); simnet.mineEmptyBlocks(10); }
+      withdrawStake(user1, cid);
+
+      const result = simnet.callPublicFn("habit-tracker", "claim-bonus", [Cl.uint(cid)], user1);
+      // Should be capped at 1 STX = 1,000,000 microSTX
+      expect(result.result).toEqual(Cl.ok(Cl.uint(1_000_000)));
     });
 
     it("should reject bonus claim by non-owner", () => {


### PR DESCRIPTION
## Problem

The `claim-bonus` function awarded 10% of the current pool per claim. Since each claim shrinks the pool, earlier claimants got significantly more than later ones:

| Claimant | Old (10%) | New (1% capped) |
|----------|-----------|-----------------|
| User A   | 0.100 STX | 0.010 STX       |
| User B   | 0.090 STX | 0.0099 STX      |
| User C   | 0.081 STX | 0.0098 STX      |
| **Spread** | **~23%** | **~1%**        |

This created a race condition incentive — users who claimed faster got more, which isn't aligned with the habit-tracking purpose.

## Fix

1. **`BONUS-DIVISOR u100`** — reduced from 10% to 1% of pool per claim
2. **`MAX-BONUS-AMOUNT u1000000`** (1 STX) — caps individual claims to prevent large extractions
3. **Zero-bonus guard** — rejects claim when pool is too small to yield any bonus

## Tests

- **Fairness test**: Two consecutive claimants receive bonuses within <2% of each other
- **Cap test**: When pool > 100 STX, bonus is capped at exactly 1 STX
- Updated existing bonus test for new 1% calculation

All 226 tests pass (38 contract tests).

Closes #77