### PR TITLE
Feature/habit creation flow

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -15,6 +15,11 @@ Creates a new habit with stake commitment.
 - `name` (string-utf8 50) - Habit description
 - `stake-amount` (uint) - Amount in microSTX
 
+**Limits:**
+- Minimum stake: 20,000 microSTX (0.02 STX)
+- Maximum stake: 100,000,000 microSTX (100 STX)
+- Habit name length: up to 50 UTF-8 characters
+
 **Returns:** habit-id (uint)
 
 **Errors:**

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -26,6 +26,11 @@ Creates a new habit with stake commitment.
 - `name` (string-utf8 50): Habit description
 - `stake-amount` (uint): Amount to stake in microSTX
 
+**Limits:**
+- Minimum stake: 20,000 microSTX (0.02 STX)
+- Maximum stake: 100,000,000 microSTX (100 STX)
+- Habit name length: up to 50 UTF-8 characters
+
 **Returns:**
 - Success: `(ok uint)` - The habit ID
 - Error: See error codes below

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -54,6 +54,10 @@ Purchase STX from:
 
 Yes, up to 100 STX per habit (100,000,000 microSTX). Higher stakes = stronger commitment.
 
+### How long can my habit name be?
+
+Habit names can be up to 50 UTF-8 characters.
+
 ### How often must I check in?
 
 Once every 24 hours (144 blocks on Stacks).

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -8,7 +8,7 @@ AhhbitTracker is a blockchain-based habit tracking system that uses financial co
 
 ### 1. Stake STX on Your Habit
 
-When you create a habit, you stake STX tokens as a commitment. The minimum stake is 0.02 STX.
+When you create a habit, you stake STX tokens as a commitment. The stake must be between 0.02 and 100 STX, and the habit name can be up to 50 characters.
 
 **Why stake?** Financial commitment creates real accountability.
 
@@ -39,7 +39,7 @@ Successful users can claim bonuses from the forfeited pool created by users who 
 1. Connect your Stacks wallet
 2. Click "Create New Habit"
 3. Enter habit name (e.g., "Morning Exercise")
-4. Set your stake amount (minimum 0.02 STX)
+4. Set your stake amount (0.02 to 100 STX)
 5. Confirm the transaction
 
 **Transaction cost:** ~0.15-0.25 STX

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -78,3 +78,4 @@ src/
 - **Rate limiting** — `RateLimitBanner` listens for 429 events from `@tanstack/react-query` retry logic
 - **Dev proxy** — In development, Vite proxies `/api/stacks/*` to `https://api.mainnet.hiro.so` to avoid CORS
 - **Production** — Uses `STACKS_MAINNET` from `@stacks/network` directly (no proxy needed)
+- **Create habit flow** — The habit form enforces the contract's 0.02-100 STX stake range and 50-character name limit before submitting a `create-habit` call

--- a/frontend/src/__tests__/HabitForm.test.tsx
+++ b/frontend/src/__tests__/HabitForm.test.tsx
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { HabitForm } from '../components/HabitForm';
+
+const createHabit = vi.fn().mockResolvedValue('tx-create');
+const showToast = vi.fn();
+
+vi.mock('../hooks/useHabits', () => ({
+  useHabits: () => ({
+    createHabit,
+    isCreatingHabit: false,
+  }),
+}));
+
+vi.mock('../context/ToastContext', () => ({
+  useToast: () => ({
+    showToast,
+  }),
+}));
+
+describe('HabitForm', () => {
+  beforeEach(() => {
+    createHabit.mockClear();
+    showToast.mockClear();
+  });
+
+  it('starts with the contract minimum stake', () => {
+    render(<HabitForm />);
+
+    expect(screen.getByLabelText('Stake Amount (STX)')).toHaveValue(0.02);
+    expect(screen.getByText('Min 0.02 STX · Max 100 STX')).toBeDefined();
+  });
+
+  it('submits a trimmed habit name and microSTX stake', async () => {
+    render(<HabitForm />);
+
+    fireEvent.change(screen.getByLabelText('Habit Name'), {
+      target: { value: '  Daily Exercise  ' },
+    });
+    fireEvent.change(screen.getByLabelText('Stake Amount (STX)'), {
+      target: { value: '0.5' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Habit' }));
+
+    await waitFor(() => expect(createHabit).toHaveBeenCalledTimes(1));
+    expect(createHabit).toHaveBeenCalledWith({
+      name: 'Daily Exercise',
+      stakeAmount: 500000,
+    });
+    expect(showToast).toHaveBeenCalledWith(
+      'Transaction signed! Your habit will appear once confirmed on-chain.',
+      'success',
+    );
+  });
+});

--- a/frontend/src/__tests__/HabitForm.test.tsx
+++ b/frontend/src/__tests__/HabitForm.test.tsx
@@ -31,6 +31,12 @@ describe('HabitForm', () => {
     expect(screen.getByText('Min 0.02 STX · Max 100 STX')).toBeDefined();
   });
 
+  it('caps habit names at the contract limit', () => {
+    render(<HabitForm />);
+
+    expect(screen.getByLabelText('Habit Name')).toHaveAttribute('maxlength', '50');
+  });
+
   it('submits a trimmed habit name and microSTX stake', async () => {
     render(<HabitForm />);
 

--- a/frontend/src/__tests__/HabitForm.test.tsx
+++ b/frontend/src/__tests__/HabitForm.test.tsx
@@ -52,4 +52,20 @@ describe('HabitForm', () => {
       'success',
     );
   });
+
+  it('rejects a stake above the contract maximum', async () => {
+    render(<HabitForm />);
+
+    fireEvent.change(screen.getByLabelText('Habit Name'), {
+      target: { value: 'Daily Exercise' },
+    });
+    fireEvent.change(screen.getByLabelText('Stake Amount (STX)'), {
+      target: { value: '101' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Create Habit' }));
+
+    expect(await screen.findByText('Maximum stake is 100 STX')).toBeDefined();
+    expect(createHabit).not.toHaveBeenCalled();
+    expect(showToast).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/__tests__/HabitForm.test.tsx
+++ b/frontend/src/__tests__/HabitForm.test.tsx
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { HabitForm } from '../components/HabitForm';
+import { MAX_HABIT_NAME_LENGTH, MAX_STAKE_AMOUNT, MIN_STAKE_AMOUNT } from '../utils/constants';
 
 const createHabit = vi.fn().mockResolvedValue('tx-create');
 const showToast = vi.fn();
@@ -27,14 +28,21 @@ describe('HabitForm', () => {
   it('starts with the contract minimum stake', () => {
     render(<HabitForm />);
 
-    expect(screen.getByLabelText('Stake Amount (STX)')).toHaveValue(0.02);
-    expect(screen.getByText('Min 0.02 STX · Max 100 STX')).toBeDefined();
+    expect(screen.getByLabelText('Stake Amount (STX)')).toHaveValue(MIN_STAKE_AMOUNT / 1_000_000);
+    expect(
+      screen.getByText(
+        `Min ${(MIN_STAKE_AMOUNT / 1_000_000).toFixed(2)} STX · Max ${(MAX_STAKE_AMOUNT / 1_000_000).toFixed(0)} STX`,
+      ),
+    ).toBeDefined();
   });
 
   it('caps habit names at the contract limit', () => {
     render(<HabitForm />);
 
-    expect(screen.getByLabelText('Habit Name')).toHaveAttribute('maxlength', '50');
+    expect(screen.getByLabelText('Habit Name')).toHaveAttribute(
+      'maxlength',
+      MAX_HABIT_NAME_LENGTH.toString(),
+    );
   });
 
   it('submits a trimmed habit name and microSTX stake', async () => {
@@ -68,7 +76,7 @@ describe('HabitForm', () => {
     fireEvent.change(screen.getByLabelText('Stake Amount (STX)'), {
       target: { value: '101' },
     });
-    fireEvent.click(screen.getByRole('button', { name: 'Create Habit' }));
+    fireEvent.submit(screen.getByRole('button', { name: 'Create Habit' }).closest('form'));
 
     expect(await screen.findByText('Maximum stake is 100 STX')).toBeDefined();
     expect(createHabit).not.toHaveBeenCalled();

--- a/frontend/src/__tests__/contractService.test.ts
+++ b/frontend/src/__tests__/contractService.test.ts
@@ -111,6 +111,15 @@ describe('contractService', () => {
   describe('createHabit', () => {
     it('resolves with the transaction ID on approval', async () => {
       const promise = contractService.createHabit('Running', 500_000);
+      expect(mocks.buildCreateHabit).toHaveBeenCalledWith(
+        'Running',
+        500_000,
+        'SP2ABC123',
+        {
+          contractAddress: 'SP000000000000000000002Q6VF78',
+          contractName: 'ahhbit-tracker',
+        },
+      );
       requireCapturedOptions().onFinish({ txId: 'tx-create' });
       await expect(promise).resolves.toBe('tx-create');
     });

--- a/frontend/src/__tests__/contractService.test.ts
+++ b/frontend/src/__tests__/contractService.test.ts
@@ -174,6 +174,13 @@ describe('contractService', () => {
   });
 
   describe('wallet guard', () => {
+    it('createHabit throws when wallet is not connected', async () => {
+      vi.spyOn(walletService, 'getAddress').mockReturnValueOnce(null);
+      await expect(contractService.createHabit('Running', 500_000)).rejects.toThrow(
+        'Wallet not connected',
+      );
+    });
+
     it('withdrawStake throws when wallet is not connected', async () => {
       vi.spyOn(walletService, 'getAddress').mockReturnValueOnce(null);
       await expect(contractService.withdrawStake(1, 1_000_000)).rejects.toThrow('Wallet not connected');

--- a/frontend/src/__tests__/contractService.test.ts
+++ b/frontend/src/__tests__/contractService.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+const mocks = vi.hoisted(() => ({
+  buildCreateHabit: vi.fn(),
+}));
+
 // Capture the options passed to showContractCall so we can invoke callbacks
 interface MockContractCallOptions {
   onFinish: (data: { txId: string }) => void;
@@ -35,14 +39,7 @@ vi.mock('@stacks/transactions', () => ({
 }));
 
 vi.mock('@yusufolosun/ahhbit-tracker-sdk', () => ({
-  buildCreateHabit: () => ({
-    contractAddress: 'SP000000000000000000002Q6VF78',
-    contractName: 'ahhbit-tracker',
-    functionName: 'create-habit',
-    functionArgs: [],
-    postConditions: [],
-    postConditionMode: 2,
-  }),
+  buildCreateHabit: mocks.buildCreateHabit,
   buildCheckIn: () => ({
     contractAddress: 'SP000000000000000000002Q6VF78',
     contractName: 'ahhbit-tracker',
@@ -101,6 +98,14 @@ import { walletService } from '../services/walletService';
 describe('contractService', () => {
   beforeEach(() => {
     capturedOptions = null;
+    mocks.buildCreateHabit.mockReturnValue({
+      contractAddress: 'SP000000000000000000002Q6VF78',
+      contractName: 'ahhbit-tracker',
+      functionName: 'create-habit',
+      functionArgs: [],
+      postConditions: [],
+      postConditionMode: 2,
+    });
   });
 
   describe('createHabit', () => {

--- a/frontend/src/components/HabitForm.tsx
+++ b/frontend/src/components/HabitForm.tsx
@@ -18,8 +18,10 @@ function getErrorMessage(error: unknown): string {
 }
 
 export function HabitForm() {
+  const minStakeStx = MIN_STAKE_AMOUNT / 1_000_000;
+  const maxStakeStx = MAX_STAKE_AMOUNT / 1_000_000;
   const [name, setName] = useState('');
-  const [stake, setStake] = useState((MIN_STAKE_AMOUNT / 1_000_000).toString());
+  const [stake, setStake] = useState(minStakeStx.toString());
   const [error, setError] = useState<string | null>(null);
   const [lockedUntil, setLockedUntil] = useState<number | null>(null);
   const lockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -58,7 +60,7 @@ export function HabitForm() {
       await createHabit({ name: trimmedName, stakeAmount });
 
       setName('');
-      setStake((MIN_STAKE_AMOUNT / 1_000_000).toString());
+      setStake(minStakeStx.toString());
 
       // Lock the form after the wallet signs so the user can't accidentally
       // fire a duplicate transaction before the first one confirms on-chain.
@@ -116,18 +118,18 @@ export function HabitForm() {
             id="stake"
             type="number"
             className="input"
-            placeholder={(MIN_STAKE_AMOUNT / 1_000_000).toString()}
+            placeholder={minStakeStx.toString()}
             value={stake}
             onChange={(e) => setStake(e.target.value)}
-            min={(MIN_STAKE_AMOUNT / 1_000_000).toString()}
-            max={(MAX_STAKE_AMOUNT / 1_000_000).toString()}
+            min={minStakeStx.toString()}
+            max={maxStakeStx.toString()}
             step="0.01"
             required
             disabled={isDisabled}
             aria-describedby="stake-hint"
           />
           <p id="stake-hint" className="mt-1 text-xs text-surface-500 dark:text-surface-400">
-            Min {(MIN_STAKE_AMOUNT / 1_000_000).toFixed(2)} STX &middot; Max {(MAX_STAKE_AMOUNT / 1_000_000).toFixed(0)} STX
+            Min {minStakeStx.toFixed(2)} STX &middot; Max {maxStakeStx.toFixed(0)} STX
           </p>
         </div>
 

--- a/frontend/src/components/HabitForm.tsx
+++ b/frontend/src/components/HabitForm.tsx
@@ -116,7 +116,7 @@ export function HabitForm() {
             id="stake"
             type="number"
             className="input"
-            placeholder="0.1"
+            placeholder={(MIN_STAKE_AMOUNT / 1_000_000).toString()}
             value={stake}
             onChange={(e) => setStake(e.target.value)}
             min={(MIN_STAKE_AMOUNT / 1_000_000).toString()}

--- a/frontend/src/components/HabitForm.tsx
+++ b/frontend/src/components/HabitForm.tsx
@@ -3,6 +3,7 @@ import { useHabits } from '../hooks/useHabits';
 import { useToast } from '../context/ToastContext';
 import { validateHabitName, validateStakeAmount } from '../utils/validation';
 import { toMicroSTX } from '../utils/formatting';
+import { MAX_HABIT_NAME_LENGTH, MAX_STAKE_AMOUNT, MIN_STAKE_AMOUNT } from '../utils/constants';
 
 /** How long (ms) the form stays locked after the wallet signs a transaction.
  *  Long enough to outlive typical mempool propagation; short enough that a
@@ -97,13 +98,13 @@ export function HabitForm() {
             placeholder="e.g., Daily Exercise"
             value={name}
             onChange={(e) => setName(e.target.value)}
-            maxLength={50}
+            maxLength={MAX_HABIT_NAME_LENGTH}
             required
             disabled={isDisabled}
             aria-describedby={error ? 'form-error' : undefined}
           />
           <p className="mt-1 text-xs text-surface-500 dark:text-surface-400">
-            {name.length}/50 characters
+            {name.length}/{MAX_HABIT_NAME_LENGTH} characters
           </p>
         </div>
 
@@ -118,15 +119,15 @@ export function HabitForm() {
             placeholder="0.1"
             value={stake}
             onChange={(e) => setStake(e.target.value)}
-            min="0.02"
-            max="100"
+            min={(MIN_STAKE_AMOUNT / 1_000_000).toString()}
+            max={(MAX_STAKE_AMOUNT / 1_000_000).toString()}
             step="0.01"
             required
             disabled={isDisabled}
             aria-describedby="stake-hint"
           />
           <p id="stake-hint" className="mt-1 text-xs text-surface-500 dark:text-surface-400">
-            Min 0.02 STX &middot; Max 100 STX
+            Min {(MIN_STAKE_AMOUNT / 1_000_000).toFixed(2)} STX &middot; Max {(MAX_STAKE_AMOUNT / 1_000_000).toFixed(0)} STX
           </p>
         </div>
 

--- a/frontend/src/components/HabitForm.tsx
+++ b/frontend/src/components/HabitForm.tsx
@@ -19,7 +19,7 @@ function getErrorMessage(error: unknown): string {
 
 export function HabitForm() {
   const [name, setName] = useState('');
-  const [stake, setStake] = useState('0.1');
+  const [stake, setStake] = useState((MIN_STAKE_AMOUNT / 1_000_000).toString());
   const [error, setError] = useState<string | null>(null);
   const [lockedUntil, setLockedUntil] = useState<number | null>(null);
   const lockTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -58,7 +58,7 @@ export function HabitForm() {
       await createHabit({ name: trimmedName, stakeAmount });
 
       setName('');
-      setStake('0.1');
+      setStake((MIN_STAKE_AMOUNT / 1_000_000).toString());
 
       // Lock the form after the wallet signs so the user can't accidentally
       // fire a duplicate transaction before the first one confirms on-chain.

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -65,6 +65,7 @@ mobile/src/
 - The preview tab is the canonical wallet handoff surface for copying signing links and reviewing callback summaries
 - Address-dependent routes are protected with a reusable guard component
 - Transaction previews are shared between screens through a dedicated context provider
+- The create-habit preview flow enforces the contract's 0.02-100 STX stake range and 50-character name limit before building the wallet handoff payload
 
 ## Local Development
 

--- a/mobile/src/app/screens/CreateHabitScreen.tsx
+++ b/mobile/src/app/screens/CreateHabitScreen.tsx
@@ -7,13 +7,10 @@ import {
   CreateHabitPreviewCard,
 } from '@/features/transactions';
 import { Screen, SectionHeader } from '@/shared/components';
+import { toMicroSTX } from '@/shared/utils';
 import { palette, radius, spacing, typography } from '@/shared/theme';
 
 type CreateHabitScreenProps = RootStackScreenProps<'CreateHabit'>;
-
-function stxToMicroStx(stxAmount: number): number {
-  return Math.round(stxAmount * 1_000_000);
-}
 
 export function CreateHabitScreen({ navigation }: CreateHabitScreenProps) {
   const { activeAddress } = useAddressState();
@@ -24,9 +21,7 @@ export function CreateHabitScreen({ navigation }: CreateHabitScreenProps) {
       return;
     }
 
-    setPreview(
-      buildCreateHabitPreview(activeAddress, name, stxToMicroStx(stakeAmountStx)),
-    );
+    setPreview(buildCreateHabitPreview(activeAddress, name, toMicroSTX(stakeAmountStx)));
 
     navigation.navigate('MainTabs', { screen: MAIN_TAB_ROUTES.Preview });
   };

--- a/mobile/src/app/screens/DashboardScreen.tsx
+++ b/mobile/src/app/screens/DashboardScreen.tsx
@@ -19,11 +19,9 @@ import {
   TransactionPreviewPanel,
 } from '@/features/transactions';
 import { EmptyState, LoadingState, Screen, SectionHeader } from '@/shared/components';
+import { toMicroSTX } from '@/shared/utils';
 import { palette, spacing, typography } from '@/shared/theme';
 
-function stxToMicroStx(stxAmount: number): number {
-  return Math.round(stxAmount * 1_000_000);
-}
 
 export function DashboardScreen() {
   const { activeAddress, isHydrating, setAddress, clearAddress } = useAddressState();
@@ -38,7 +36,7 @@ export function DashboardScreen() {
       return;
     }
 
-    const stakeAmountMicroStx = stxToMicroStx(stakeAmountStx);
+    const stakeAmountMicroStx = toMicroSTX(stakeAmountStx);
     setPreview(buildCreateHabitPreview(activeAddress, name, stakeAmountMicroStx));
   };
 

--- a/mobile/src/core/config/constants.ts
+++ b/mobile/src/core/config/constants.ts
@@ -2,6 +2,7 @@ import { DEFAULT_MIN_STAKE } from '@yusufolosun/stx-utils';
 
 export const APP_LINK_SCHEME = 'ahhbittracker';
 export const MIN_STAKE_AMOUNT = DEFAULT_MIN_STAKE;
+export const MAX_STAKE_AMOUNT = 100_000_000;
 export const MAX_HABIT_NAME_LENGTH = 50;
 export const CHECK_IN_WINDOW_BLOCKS = 144;
 export const MIN_STREAK_FOR_WITHDRAWAL = 7;

--- a/mobile/src/features/transactions/components/CreateHabitPreviewCard.tsx
+++ b/mobile/src/features/transactions/components/CreateHabitPreviewCard.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react-native';
 import { Card } from '@/shared/components';
 import { palette, radius, spacing, typography } from '@/shared/theme';
+import { MAX_HABIT_NAME_LENGTH, MAX_STAKE_AMOUNT, MIN_STAKE_AMOUNT } from '@/core/config';
 import { validateHabitName, validateHabitStake } from '@/shared/utils';
 
 interface CreateHabitPreviewCardProps {
@@ -59,6 +60,7 @@ export function CreateHabitPreviewCard({ onPreview }: CreateHabitPreviewCardProp
         placeholderTextColor={palette.steel}
         style={styles.input}
         value={habitName}
+        maxLength={MAX_HABIT_NAME_LENGTH}
       />
       <TextInput
         keyboardType="decimal-pad"
@@ -68,6 +70,9 @@ export function CreateHabitPreviewCard({ onPreview }: CreateHabitPreviewCardProp
         style={styles.input}
         value={stake}
       />
+      <Text style={styles.hint}>
+        Min {MIN_STAKE_AMOUNT / 1_000_000} STX · Max {MAX_STAKE_AMOUNT / 1_000_000} STX · Up to {MAX_HABIT_NAME_LENGTH} characters
+      </Text>
       {error ? <Text style={styles.error}>{error}</Text> : null}
       <Pressable
         accessibilityRole="button"
@@ -109,6 +114,11 @@ const styles = StyleSheet.create({
   },
   error: {
     color: palette.danger,
+    marginBottom: spacing.sm,
+  },
+  hint: {
+    color: palette.steel,
+    fontSize: typography.caption,
     marginBottom: spacing.sm,
   },
   previewButton: {

--- a/mobile/src/features/transactions/components/CreateHabitPreviewCard.tsx
+++ b/mobile/src/features/transactions/components/CreateHabitPreviewCard.tsx
@@ -31,9 +31,7 @@ export function CreateHabitPreviewCard({ onPreview }: CreateHabitPreviewCardProp
   const isDisabled = useMemo(() => !habitName.trim() || !stake.trim(), [habitName, stake]);
 
   useEffect(() => {
-    if (error) {
-      setError(null);
-    }
+    setError(null);
   }, [habitName, stake]);
 
   const handlePreview = () => {

--- a/mobile/src/features/transactions/components/CreateHabitPreviewCard.tsx
+++ b/mobile/src/features/transactions/components/CreateHabitPreviewCard.tsx
@@ -122,7 +122,7 @@ const styles = StyleSheet.create({
   },
   hint: {
     color: palette.steel,
-    fontSize: typography.caption,
+    fontSize: typography.label,
     marginBottom: spacing.sm,
   },
   previewButton: {

--- a/mobile/src/features/transactions/components/CreateHabitPreviewCard.tsx
+++ b/mobile/src/features/transactions/components/CreateHabitPreviewCard.tsx
@@ -24,6 +24,8 @@ function normalizeStake(value: string): number {
 }
 
 export function CreateHabitPreviewCard({ onPreview }: CreateHabitPreviewCardProps) {
+  const minStakeStx = MIN_STAKE_AMOUNT / 1_000_000;
+  const maxStakeStx = MAX_STAKE_AMOUNT / 1_000_000;
   const [habitName, setHabitName] = useState('');
   const [stake, setStake] = useState('0.02');
   const [error, setError] = useState<string | null>(null);
@@ -75,7 +77,7 @@ export function CreateHabitPreviewCard({ onPreview }: CreateHabitPreviewCardProp
         value={stake}
       />
       <Text style={styles.hint}>
-        Min {MIN_STAKE_AMOUNT / 1_000_000} STX · Max {MAX_STAKE_AMOUNT / 1_000_000} STX · Up to {MAX_HABIT_NAME_LENGTH} characters
+        Min {minStakeStx} STX · Max {maxStakeStx} STX · Up to {MAX_HABIT_NAME_LENGTH} characters
       </Text>
       {error ? <Text style={styles.error}>{error}</Text> : null}
       <Pressable

--- a/mobile/src/features/transactions/components/CreateHabitPreviewCard.tsx
+++ b/mobile/src/features/transactions/components/CreateHabitPreviewCard.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import {
   Pressable,
   StyleSheet,
@@ -29,6 +29,12 @@ export function CreateHabitPreviewCard({ onPreview }: CreateHabitPreviewCardProp
   const [error, setError] = useState<string | null>(null);
 
   const isDisabled = useMemo(() => !habitName.trim() || !stake.trim(), [habitName, stake]);
+
+  useEffect(() => {
+    if (error) {
+      setError(null);
+    }
+  }, [habitName, stake]);
 
   const handlePreview = () => {
     const normalizedName = habitName.trim();

--- a/mobile/src/shared/utils/formatting.ts
+++ b/mobile/src/shared/utils/formatting.ts
@@ -1,4 +1,4 @@
-import { formatSTX, shortenAddress } from '@yusufolosun/stx-utils';
+import { formatSTX, shortenAddress, toMicroSTX } from '@yusufolosun/stx-utils';
 
 export function formatMicroStx(microStx: number): string {
   return `${formatSTX(microStx)} STX`;
@@ -11,3 +11,5 @@ export function formatStreakDays(value: number): string {
 export function formatAddress(value: string): string {
   return shortenAddress(value);
 }
+
+export { toMicroSTX };

--- a/mobile/src/shared/utils/validation.ts
+++ b/mobile/src/shared/utils/validation.ts
@@ -1,12 +1,12 @@
 import { validateName, validatePrincipal, validateStake } from '@yusufolosun/stx-utils';
-import { MIN_STAKE_AMOUNT } from '@/core/config';
+import { MAX_HABIT_NAME_LENGTH, MIN_STAKE_AMOUNT } from '@/core/config';
 
 export function validateStacksAddress(value: string): string | null {
   return validatePrincipal(value.trim());
 }
 
 export function validateHabitName(value: string): string | null {
-  return validateName(value.trim());
+  return validateName(value.trim(), MAX_HABIT_NAME_LENGTH);
 }
 
 export function validateHabitStake(stxAmount: number): string | null {

--- a/mobile/src/shared/utils/validation.ts
+++ b/mobile/src/shared/utils/validation.ts
@@ -1,5 +1,5 @@
-import { validateName, validatePrincipal, validateStake } from '@yusufolosun/stx-utils';
-import { MAX_HABIT_NAME_LENGTH, MIN_STAKE_AMOUNT } from '@/core/config';
+import { toMicroSTX, validateName, validatePrincipal, validateStake } from '@yusufolosun/stx-utils';
+import { MAX_HABIT_NAME_LENGTH, MAX_STAKE_AMOUNT, MIN_STAKE_AMOUNT } from '@/core/config';
 
 export function validateStacksAddress(value: string): string | null {
   return validatePrincipal(value.trim());
@@ -10,5 +10,15 @@ export function validateHabitName(value: string): string | null {
 }
 
 export function validateHabitStake(stxAmount: number): string | null {
-  return validateStake(stxAmount, MIN_STAKE_AMOUNT);
+  const minErr = validateStake(stxAmount, MIN_STAKE_AMOUNT);
+
+  if (minErr) {
+    return minErr;
+  }
+
+  if (toMicroSTX(stxAmount) > MAX_STAKE_AMOUNT) {
+    return `Maximum stake is ${MAX_STAKE_AMOUNT / 1_000_000} STX`;
+  }
+
+  return null;
 }


### PR DESCRIPTION
This PR aligns the habit creation flow with the _create-habit_ contract interface across web and mobile. It updates the UI and validation to enforce the on-chain habit name and stake limits before submission, and keeps the mobile create flow consistent with the wallet preview handoff pattern already used in the app.

It also updates the related docs so the contract limits and creation flow are described consistently in the README, user guide, FAQ, and API reference.

Verification
Frontend Vitest suite passed, and the mobile TypeScript check passed.