### PR TITLE
Feat/bonus claim distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ npm run preview       # Preview locally
 | `claim-bonus` | Claim share of forfeited pool |
 | `get-habit` | Read habit details |
 | `get-pool-balance` | View total forfeited STX |
+| `get-unclaimed-completed-habits` | View pending bonus claimant count |
+| `get-estimated-bonus-share` | View next estimated bonus share |
 
 Full reference → [docs/API_REFERENCE.md](docs/API_REFERENCE.md)
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -60,6 +60,10 @@ Claims bonus from forfeited pool.
 
 **Returns:** Bonus amount (uint)
 
+**Distribution model:**
+- Bonus is computed as `forfeited-pool-balance / unclaimed-completed-habits`
+- Integer division is used; any remainder is preserved in the pool for later claims
+
 **Errors:**
 - `ERR-POOL-INSUFFICIENT-BALANCE` - Pool empty
 
@@ -100,6 +104,16 @@ Gets total balance in forfeited pool.
 
 **Returns:** Pool balance in microSTX
 
+#### get-unclaimed-completed-habits
+Gets total number of completed habits that have not claimed a bonus.
+
+**Returns:** Eligible claimant count (uint)
+
+#### get-estimated-bonus-share
+Gets the current estimated payout for the next successful claim.
+
+**Returns:** Estimated bonus amount in microSTX (uint)
+
 #### get-user-stats
 Gets aggregated statistics for a user.
 
@@ -126,6 +140,7 @@ Links users to their habit IDs.
 ### Data Variables
 - `habit-id-nonce` - Counter for generating unique IDs
 - `forfeited-pool-balance` - Total STX in forfeiture pool
+- `unclaimed-completed-habits` - Eligible completed habits pending bonus claim
 
 ## Testing
 

--- a/contracts/habit-tracker-v2.clar
+++ b/contracts/habit-tracker-v2.clar
@@ -409,6 +409,7 @@
     
     ;; Update pool balance
     (var-set forfeited-pool-balance (- pool-balance bonus-amount))
+    (var-set unclaimed-completed-habits (- eligible-claimants u1))
 
     ;; Mark bonus as claimed to prevent re-entrancy
     (map-set habits

--- a/contracts/habit-tracker-v2.clar
+++ b/contracts/habit-tracker-v2.clar
@@ -468,6 +468,17 @@
   (ok (var-get unclaimed-completed-habits))
 )
 
+;; Estimate next claim amount based on current pool and claimant count
+(define-read-only (get-estimated-bonus-share)
+  (let
+    (
+      (pool-balance (var-get forfeited-pool-balance))
+      (eligible-claimants (var-get unclaimed-completed-habits))
+    )
+    (ok (calculate-bonus-share pool-balance eligible-claimants))
+  )
+)
+
 ;; Get total habits created
 (define-read-only (get-total-habits)
   (ok (var-get habit-id-nonce))

--- a/contracts/habit-tracker-v2.clar
+++ b/contracts/habit-tracker-v2.clar
@@ -146,6 +146,15 @@
   )
 )
 
+;; Calculate equal-share bonus amount for the next claimant.
+;; Integer division intentionally leaves any remainder for later claimants.
+(define-private (calculate-bonus-share (pool-balance uint) (eligible-claimants uint))
+  (if (> eligible-claimants u0)
+    (/ pool-balance eligible-claimants)
+    u0
+  )
+)
+
 ;; ============================================
 ;; PUBLIC FUNCTIONS - HABIT MANAGEMENT
 ;; ============================================

--- a/contracts/habit-tracker-v2.clar
+++ b/contracts/habit-tracker-v2.clar
@@ -423,6 +423,8 @@
       habit-id: habit-id,
       owner: caller,
       amount: bonus-amount,
+      claimant-count: eligible-claimants,
+      remaining-claimants: (- eligible-claimants u1),
       remaining-pool: (- pool-balance bonus-amount),
       block: block-height
     })

--- a/contracts/habit-tracker-v2.clar
+++ b/contracts/habit-tracker-v2.clar
@@ -463,6 +463,11 @@
   (ok (var-get forfeited-pool-balance))
 )
 
+;; Get number of completed habits that have not yet claimed bonus
+(define-read-only (get-unclaimed-completed-habits)
+  (ok (var-get unclaimed-completed-habits))
+)
+
 ;; Get total habits created
 (define-read-only (get-total-habits)
   (ok (var-get habit-id-nonce))

--- a/contracts/habit-tracker-v2.clar
+++ b/contracts/habit-tracker-v2.clar
@@ -93,6 +93,9 @@
 ;; Forfeited stakes pool (total available for distribution)
 (define-data-var forfeited-pool-balance uint u0)
 
+;; Number of completed habits that are still eligible to claim bonus
+(define-data-var unclaimed-completed-habits uint u0)
+
 ;; ============================================
 ;; PRIVATE HELPER FUNCTIONS
 ;; ============================================

--- a/contracts/habit-tracker-v2.clar
+++ b/contracts/habit-tracker-v2.clar
@@ -387,9 +387,8 @@
       (caller tx-sender)
       (habit (unwrap! (map-get? habits { habit-id: habit-id }) ERR-HABIT-NOT-FOUND))
       (pool-balance (var-get forfeited-pool-balance))
-      ;; Bonus: 1% of pool, capped at MAX-BONUS-AMOUNT (1 STX)
-      (raw-bonus (/ pool-balance BONUS-DIVISOR))
-      (bonus-amount (if (<= raw-bonus MAX-BONUS-AMOUNT) raw-bonus MAX-BONUS-AMOUNT))
+      (eligible-claimants (var-get unclaimed-completed-habits))
+      (bonus-amount (calculate-bonus-share pool-balance eligible-claimants))
     )
     ;; Verify caller is habit owner
     (asserts! (is-eq caller (get owner habit)) ERR-NOT-HABIT-OWNER)
@@ -401,6 +400,7 @@
     (asserts! (not (get bonus-claimed habit)) ERR-BONUS-ALREADY-CLAIMED)
     
     ;; Verify pool has sufficient balance and bonus is non-zero
+    (asserts! (> eligible-claimants u0) ERR-POOL-INSUFFICIENT-BALANCE)
     (asserts! (> bonus-amount u0) ERR-POOL-INSUFFICIENT-BALANCE)
     (asserts! (>= pool-balance bonus-amount) ERR-POOL-INSUFFICIENT-BALANCE)
     

--- a/contracts/habit-tracker-v2.clar
+++ b/contracts/habit-tracker-v2.clar
@@ -360,6 +360,9 @@
         is-completed: true
       })
     )
+
+    ;; Completed habits become eligible for a single pool bonus claim.
+    (var-set unclaimed-completed-habits (+ (var-get unclaimed-completed-habits) u1))
     
     ;; Emit event
     (print {

--- a/contracts/habit-tracker-v2.clar
+++ b/contracts/habit-tracker-v2.clar
@@ -38,9 +38,8 @@
 ;; Minimum streak required for withdrawal
 (define-constant MIN-STREAK-FOR-WITHDRAWAL u7)
 
-;; Bonus distribution: 1% of pool per claim, capped at 1 STX
-(define-constant BONUS-DIVISOR u100)
-(define-constant MAX-BONUS-AMOUNT u1000000)
+;; Bonus distribution uses dynamic equal-share allocation across
+;; completed habits that have not claimed yet.
 
 ;; ============================================
 ;; ERROR CODES

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -160,6 +160,11 @@ Claims bonus from forfeited pool.
 - Caller must own the habit
 - Habit must be completed (withdrawn)
 - Pool must have balance
+- At least one unclaimed completed habit must exist
+
+**Payout Formula:**
+- `bonus-amount = forfeited-pool-balance / unclaimed-completed-habits`
+- Integer remainder stays in the pool and is settled by later claims
 
 **Gas Cost:** ~60,000 microSTX
 
@@ -280,6 +285,38 @@ Gets total balance in forfeited pool.
 ```
 
 **Gas Cost:** Free (read-only)
+
+---
+
+### get-unclaimed-completed-habits
+
+Gets the number of completed habits that are eligible to claim bonus.
+
+**Signature:**
+```clarity
+(define-read-only (get-unclaimed-completed-habits))
+```
+
+**Parameters:** None
+
+**Returns:**
+- `(ok uint)` - Pending claimant count
+
+---
+
+### get-estimated-bonus-share
+
+Gets the estimated payout for the next successful bonus claim.
+
+**Signature:**
+```clarity
+(define-read-only (get-estimated-bonus-share))
+```
+
+**Parameters:** None
+
+**Returns:**
+- `(ok uint)` - Estimated next bonus amount in microSTX
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -105,9 +105,10 @@ User → withdraw-stake(habit-id) → Contract
 ```
 User → claim-bonus(habit-id) → Contract
   ├─ Verify user has completed habits
-  ├─ Calculate user's share of pool
+  ├─ Read forfeited pool and unclaimed completed claimant count
+  ├─ Calculate equal share using integer division
   ├─ Transfer bonus from pool to user
-  ├─ Update pool balance
+  ├─ Update pool balance and claimant count
   └─ Emit claim event
 ```
 
@@ -185,6 +186,11 @@ If user checks in after 144 blocks from last check-in, streak is broken and stak
 
 **Forfeited pool:** 30 STX
 **Per successful user bonus:** 30 STX ÷ 70 = **~0.43 STX**
+
+In implementation, payout is recalculated per claim as:
+`forfeited-pool-balance / unclaimed-completed-habits`
+
+This keeps accounting accurate on-chain while preserving any integer remainder for subsequent claims.
 
 **ROI for successful user:**
 - Stake recovered: 1 STX

--- a/frontend/src/__tests__/HabitCard.test.tsx
+++ b/frontend/src/__tests__/HabitCard.test.tsx
@@ -14,6 +14,8 @@ vi.mock('../hooks/useHabits', () => ({
     claimBonus: vi.fn(),
     slashHabit: vi.fn(),
     poolBalance: 50_000_000,
+    estimatedBonusShare: 500_000,
+    unclaimedCompletedHabits: 4,
     pendingCheckIns: new Set<number>(),
     pendingWithdrawals: new Set<number>(),
     pendingClaims: new Set<number>(),
@@ -122,7 +124,7 @@ describe('HabitCard', () => {
   it('displays estimated bonus in claim dialog', () => {
     render(<HabitCard habit={completedHabit} />, { wrapper: TestWrapper });
     fireEvent.click(screen.getByText('Claim Bonus'));
-    // poolBalance is 50_000_000 → 1% = 500_000 microSTX → formatSTX = "0.50"
+    // estimatedBonusShare is 500_000 microSTX → formatSTX = "0.50"
     expect(screen.getByText('Est. Bonus')).toBeDefined();
     expect(screen.getByText('0.50 STX')).toBeDefined();
   });

--- a/frontend/src/__tests__/contractService.test.ts
+++ b/frontend/src/__tests__/contractService.test.ts
@@ -94,10 +94,13 @@ vi.mock('../utils/constants', () => ({
 // Import after mocks are set up
 import { contractService } from '../services/contractService';
 import { walletService } from '../services/walletService';
+import { cvToJSON, fetchCallReadOnlyFunction } from '@stacks/transactions';
 
 describe('contractService', () => {
   beforeEach(() => {
     capturedOptions = null;
+    vi.mocked(fetchCallReadOnlyFunction).mockReset();
+    vi.mocked(cvToJSON).mockReset();
     mocks.buildCreateHabit.mockReturnValue({
       contractAddress: 'SP000000000000000000002Q6VF78',
       contractName: 'ahhbit-tracker',
@@ -105,6 +108,32 @@ describe('contractService', () => {
       functionArgs: [],
       postConditions: [],
       postConditionMode: 2,
+    });
+  });
+
+  describe('read-only distribution helpers', () => {
+    it('reads estimated bonus share', async () => {
+      vi.mocked(fetchCallReadOnlyFunction).mockResolvedValueOnce({} as any);
+      vi.mocked(cvToJSON).mockReturnValueOnce({ success: true, value: { value: 500_000 } } as any);
+
+      const result = await contractService.readEstimatedBonusShare();
+
+      expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(
+        expect.objectContaining({ functionName: 'get-estimated-bonus-share' }),
+      );
+      expect(result).toBe(500_000);
+    });
+
+    it('reads unclaimed completed habits', async () => {
+      vi.mocked(fetchCallReadOnlyFunction).mockResolvedValueOnce({} as any);
+      vi.mocked(cvToJSON).mockReturnValueOnce({ success: true, value: { value: 3 } } as any);
+
+      const result = await contractService.readUnclaimedCompletedHabits();
+
+      expect(fetchCallReadOnlyFunction).toHaveBeenCalledWith(
+        expect.objectContaining({ functionName: 'get-unclaimed-completed-habits' }),
+      );
+      expect(result).toBe(3);
     });
   });
 

--- a/frontend/src/__tests__/useHabits.sync.test.tsx
+++ b/frontend/src/__tests__/useHabits.sync.test.tsx
@@ -52,6 +52,8 @@ vi.mock('../services/contractService', () => ({
     } satisfies Omit<Habit, 'habitId'>),
     readUserStats: vi.fn().mockResolvedValue({ totalHabits: 1, habitIds: [1] }),
     readPoolBalance: vi.fn().mockResolvedValue(0),
+    readEstimatedBonusShare: vi.fn().mockResolvedValue(0),
+    readUnclaimedCompletedHabits: vi.fn().mockResolvedValue(0),
     createHabit: vi.fn(),
     checkIn: vi.fn(),
     withdrawStake: vi.fn(),

--- a/frontend/src/components/HabitCard.tsx
+++ b/frontend/src/components/HabitCard.tsx
@@ -28,7 +28,18 @@ function getErrorMessage(error: unknown): string {
 }
 
 export function HabitCard({ habit }: HabitCardProps) {
-  const { checkIn, withdrawStake, claimBonus, slashHabit, poolBalance, pendingCheckIns, pendingWithdrawals, pendingClaims, pendingSlashes } = useHabits();
+  const {
+    checkIn,
+    withdrawStake,
+    claimBonus,
+    slashHabit,
+    estimatedBonusShare,
+    unclaimedCompletedHabits,
+    pendingCheckIns,
+    pendingWithdrawals,
+    pendingClaims,
+    pendingSlashes,
+  } = useHabits();
   const { showToast } = useToast();
   const { walletState } = useWallet();
   const [confirmAction, setConfirmAction] = useState<'withdraw' | 'claim' | 'slash' | null>(null);
@@ -99,7 +110,7 @@ export function HabitCard({ habit }: HabitCardProps) {
   const blocksUntilNextCheckIn =
     currentBlock !== null ? getBlocksUntilNextCheckIn(habit, currentBlock) : null;
   const canSubmitCheckIn = isEligibleForDailyCheckIn(habit, currentBlock);
-  const estimatedBonus = Math.min(Math.floor(poolBalance / 100), 1_000_000);
+  const estimatedBonus = estimatedBonusShare;
 
   const getBadge = () => {
     if (habit.isCompleted) return { label: 'Completed', className: 'bg-blue-100 text-blue-800 dark:bg-blue-500/15 dark:text-blue-400' };
@@ -339,7 +350,7 @@ export function HabitCard({ habit }: HabitCardProps) {
             </div>
           </dl>
           <p className="text-xs text-surface-500 dark:text-surface-400">
-            Bonus is 1% of the current pool, capped at 1 STX. The actual amount may differ slightly if the pool changes before confirmation.
+            Bonus payout is the current equal-share estimate from contract state for {unclaimedCompletedHabits || 0} pending claimant{(unclaimedCompletedHabits || 0) === 1 ? '' : 's'}. The actual amount may differ if claims settle before your transaction confirms.
           </p>
           <p className="text-xs text-amber-600 dark:text-amber-400">
             This action is irreversible and will incur a gas fee.

--- a/frontend/src/hooks/useHabits.ts
+++ b/frontend/src/hooks/useHabits.ts
@@ -95,6 +95,22 @@ export const useHabits = () => {
     retryDelay: (attempt) => Math.min(15000 * Math.pow(2, attempt - 1), 60000),
   });
 
+  const { data: estimatedBonusShare } = useQuery({
+    queryKey: ['estimatedBonusShare'],
+    queryFn: () => contractService.readEstimatedBonusShare(),
+    staleTime: POOL_CACHE_TIME,
+    retry: 3,
+    retryDelay: (attempt) => Math.min(15000 * Math.pow(2, attempt - 1), 60000),
+  });
+
+  const { data: unclaimedCompletedHabits } = useQuery({
+    queryKey: ['unclaimedCompletedHabits'],
+    queryFn: () => contractService.readUnclaimedCompletedHabits(),
+    staleTime: POOL_CACHE_TIME,
+    retry: 3,
+    retryDelay: (attempt) => Math.min(15000 * Math.pow(2, attempt - 1), 60000),
+  });
+
   // Helper: schedule a deferred refetch after the tx has time to mine.
   // Stacks blocks average ~10 min; we refetch at 30s and 2min as best-effort.
   // All timers are tracked so they can be cleaned up on unmount.
@@ -148,6 +164,8 @@ export const useHabits = () => {
 
       if (syncTargets.invalidatePoolBalance) {
         void queryClient.invalidateQueries({ queryKey: ['poolBalance'] });
+        void queryClient.invalidateQueries({ queryKey: ['estimatedBonusShare'] });
+        void queryClient.invalidateQueries({ queryKey: ['unclaimedCompletedHabits'] });
       }
 
       if (syncTargets.refreshBalance) {
@@ -225,6 +243,8 @@ export const useHabits = () => {
         ['habits', walletState.address!],
         ['userStats', walletState.address!],
         ['poolBalance'],
+        ['estimatedBonusShare'],
+        ['unclaimedCompletedHabits'],
       ]);
     },
   });
@@ -246,7 +266,12 @@ export const useHabits = () => {
     onSuccess: (txId) => {
       addTransaction(txId, 'claim-bonus');
       void refreshBalance();
-      scheduleRefetch([['habits', walletState.address!], ['poolBalance']]);
+      scheduleRefetch([
+        ['habits', walletState.address!],
+        ['poolBalance'],
+        ['estimatedBonusShare'],
+        ['unclaimedCompletedHabits'],
+      ]);
     },
   });
 
@@ -265,7 +290,11 @@ export const useHabits = () => {
     },
     onSuccess: (txId) => {
       addTransaction(txId, 'slash-habit');
-      scheduleRefetch([['habits', walletState.address!], ['poolBalance']]);
+      scheduleRefetch([
+        ['habits', walletState.address!],
+        ['poolBalance'],
+        ['estimatedBonusShare'],
+      ]);
     },
   });
 
@@ -318,6 +347,8 @@ export const useHabits = () => {
     habits: habits || [],
     userStats,
     poolBalance: poolBalance || 0,
+    estimatedBonusShare: estimatedBonusShare || 0,
+    unclaimedCompletedHabits: unclaimedCompletedHabits || 0,
 
     // Loading states
     isLoadingHabits,

--- a/frontend/src/services/contractService.ts
+++ b/frontend/src/services/contractService.ts
@@ -3,6 +3,7 @@
  * Service for interacting with the AhhbitTracker smart contract.
  */
 import { showContractCall } from '@stacks/connect';
+import { cvToJSON, fetchCallReadOnlyFunction } from '@stacks/transactions';
 import {
   buildCheckIn,
   buildClaimBonus,
@@ -17,6 +18,14 @@ import {
 import { CONTRACT_ADDRESS, CONTRACT_NAME, NETWORK } from '../utils/constants';
 import { walletService } from './walletService';
 import type { Habit, UserStats } from '../types/habit';
+
+function unwrapOkNumber(json: any): number {
+  if (json?.success === true) {
+    return Number(json.value?.value ?? 0);
+  }
+
+  return Number(json?.value ?? 0);
+}
 
 /** Application details for wallet transaction popups. */
 const appDetails = {
@@ -50,6 +59,32 @@ export const contractService = {
       contractAddress: CONTRACT_ADDRESS,
       contractName: CONTRACT_NAME,
     });
+  },
+
+  async readEstimatedBonusShare(): Promise<number> {
+    const response = await fetchCallReadOnlyFunction({
+      contractAddress: CONTRACT_ADDRESS,
+      contractName: CONTRACT_NAME,
+      functionName: 'get-estimated-bonus-share',
+      functionArgs: [],
+      network: NETWORK,
+      senderAddress: CONTRACT_ADDRESS,
+    });
+
+    return unwrapOkNumber(cvToJSON(response));
+  },
+
+  async readUnclaimedCompletedHabits(): Promise<number> {
+    const response = await fetchCallReadOnlyFunction({
+      contractAddress: CONTRACT_ADDRESS,
+      contractName: CONTRACT_NAME,
+      functionName: 'get-unclaimed-completed-habits',
+      functionArgs: [],
+      network: NETWORK,
+      senderAddress: CONTRACT_ADDRESS,
+    });
+
+    return unwrapOkNumber(cvToJSON(response));
   },
 
   async readUserStats(userAddress: string): Promise<UserStats> {

--- a/mobile/src/core/data/contractService.ts
+++ b/mobile/src/core/data/contractService.ts
@@ -5,10 +5,32 @@ import {
   getUserStats,
   type Habit as SdkHabit,
 } from '@yusufolosun/ahhbit-tracker-sdk';
+import { cvToJSON, fetchCallReadOnlyFunction } from '@stacks/transactions';
 import { formatSTX } from '@yusufolosun/stx-utils';
 import { networkConfig } from '@/core/config';
 import { stacksNetwork } from '@/core/network';
 import type { Habit, PoolBalance, UserStats } from '@/core/types';
+
+function unwrapOkNumber(json: any): number {
+  if (json?.success === true) {
+    return Number(json.value?.value ?? 0);
+  }
+
+  return Number(json?.value ?? 0);
+}
+
+async function readPoolDistributionValue(functionName: string): Promise<number> {
+  const response = await fetchCallReadOnlyFunction({
+    contractAddress: networkConfig.contract.contractAddress,
+    contractName: networkConfig.contract.contractName,
+    functionName,
+    functionArgs: [],
+    network: stacksNetwork,
+    senderAddress: networkConfig.contract.contractAddress,
+  });
+
+  return unwrapOkNumber(cvToJSON(response));
+}
 
 function toMobileHabit(habitId: number, value: SdkHabit): Habit {
   return {
@@ -50,11 +72,18 @@ export async function fetchHabitsByAddress(address: string): Promise<Habit[]> {
 }
 
 export async function fetchPoolBalance(): Promise<PoolBalance> {
-  const microStx = await getPoolBalance(stacksNetwork, networkConfig.contract);
+  const [microStx, estimatedBonusShareMicroStx, unclaimedCompletedHabits] = await Promise.all([
+    getPoolBalance(stacksNetwork, networkConfig.contract),
+    readPoolDistributionValue('get-estimated-bonus-share'),
+    readPoolDistributionValue('get-unclaimed-completed-habits'),
+  ]);
 
   return {
     microStx,
     stx: formatSTX(microStx),
+    estimatedBonusShareMicroStx,
+    estimatedBonusShareStx: formatSTX(estimatedBonusShareMicroStx),
+    unclaimedCompletedHabits,
   };
 }
 

--- a/mobile/src/core/types/habit.ts
+++ b/mobile/src/core/types/habit.ts
@@ -19,6 +19,9 @@ export interface UserStats {
 export interface PoolBalance {
   microStx: number;
   stx: string;
+  estimatedBonusShareMicroStx: number;
+  estimatedBonusShareStx: string;
+  unclaimedCompletedHabits: number;
 }
 
 export interface HabitFilters {

--- a/mobile/src/features/pool/components/PoolBalanceCard.tsx
+++ b/mobile/src/features/pool/components/PoolBalanceCard.tsx
@@ -17,7 +17,15 @@ export function PoolBalanceCard({ data, isLoading, error }: PoolBalanceCardProps
       ) : null}
       {!isLoading && error ? <Text style={styles.error}>{error.message}</Text> : null}
       {!isLoading && !error ? (
-        <Text style={styles.value}>{data ? `${data.stx} STX` : '0.00 STX'}</Text>
+        <View>
+          <Text style={styles.value}>{data ? `${data.stx} STX` : '0.00 STX'}</Text>
+          <Text style={styles.meta}>
+            Next bonus est.: {data ? `${data.estimatedBonusShareStx} STX` : '0.00 STX'}
+          </Text>
+          <Text style={styles.meta}>
+            Pending claimants: {data ? data.unclaimedCompletedHabits : 0}
+          </Text>
+        </View>
       ) : null}
     </View>
   );
@@ -41,6 +49,11 @@ const styles = StyleSheet.create({
     color: palette.card,
     fontSize: typography.heading,
     fontWeight: '700',
+  },
+  meta: {
+    color: palette.cloud,
+    fontSize: typography.label,
+    marginTop: spacing.xs,
   },
   error: {
     color: '#FECACA',

--- a/tests/habit-tracker.test.ts
+++ b/tests/habit-tracker.test.ts
@@ -415,8 +415,8 @@ describe("AhhbitTracker Contract", () => {
 
       // 4. Claim bonus
       const result = simnet.callPublicFn("habit-tracker-v2", "claim-bonus", [Cl.uint(id1)], user1);
-      // Pool had MIN_STAKE * 10 (1 STX). 1% = MIN_STAKE / 10 = 10000
-      expect(result.result).toEqual(Cl.ok(Cl.uint(MIN_STAKE / 10)));
+      // Only one eligible claimant, so claim receives the full available pool.
+      expect(result.result).toEqual(Cl.ok(Cl.uint(MIN_STAKE * 10)));
     });
 
     it("should distribute nearly equal bonuses to consecutive claimants", () => {

--- a/tests/habit-tracker.test.ts
+++ b/tests/habit-tracker.test.ts
@@ -461,18 +461,17 @@ describe("AhhbitTracker Contract", () => {
       for (let i = 0; i < 7; i++) { checkIn(user2, id2); simnet.mineEmptyBlocks(120); }
       withdrawStake(user2, id2);
 
-      // Both claim — bonuses should be within ~1% of each other
+      // Both claim from a fixed pool with two claimants.
       const claim1 = simnet.callPublicFn("habit-tracker-v2", "claim-bonus", [Cl.uint(id1)], user1);
       const claim2 = simnet.callPublicFn("habit-tracker-v2", "claim-bonus", [Cl.uint(id2)], user2);
 
       const bonus1 = Number((claim1.result as any).value.value);
       const bonus2 = Number((claim2.result as any).value.value);
 
-      // With 1% per claim, the spread between first and second is ~1%
-      // bonus1 = pool / 100, bonus2 = (pool - bonus1) / 100
+      // Share-based payout should keep consecutive claim amounts aligned.
       expect(bonus1).toBeGreaterThan(0);
       expect(bonus2).toBeGreaterThan(0);
-      // Difference should be less than 2% (much better than old 10%)
+      // Difference should stay very small for this even split setup.
       expect((bonus1 - bonus2) / bonus1).toBeLessThan(0.02);
     });
 

--- a/tests/habit-tracker.test.ts
+++ b/tests/habit-tracker.test.ts
@@ -50,6 +50,24 @@ function getHabit(habitId: number) {
   );
 }
 
+function getUnclaimedCompletedHabits() {
+  return simnet.callReadOnlyFn(
+    "habit-tracker-v2",
+    "get-unclaimed-completed-habits",
+    [],
+    deployer
+  );
+}
+
+function getEstimatedBonusShare() {
+  return simnet.callReadOnlyFn(
+    "habit-tracker-v2",
+    "get-estimated-bonus-share",
+    [],
+    deployer
+  );
+}
+
 /*
  * AhhbitTracker Contract Tests
  * Comprehensive test suite for habit tracking smart contract

--- a/tests/habit-tracker.test.ts
+++ b/tests/habit-tracker.test.ts
@@ -509,6 +509,29 @@ describe("AhhbitTracker Contract", () => {
       expect(result.result).toEqual(Cl.error(Cl.uint(104))); // ERR-NOT-HABIT-OWNER
     });
 
+    it("should update unclaimed claimant count across withdraw and claim", () => {
+      // Build pool funds from an expired habit.
+      const failHabit = createHabit(user2, "Fail for pool", MIN_STAKE);
+      const failId = Number((failHabit.result as any).value.value);
+      simnet.mineEmptyBlocks(MIN_CHECK_IN_INTERVAL);
+      checkIn(user2, failId);
+      simnet.mineEmptyBlocks(150);
+      simnet.callPublicFn("habit-tracker-v2", "slash-habit", [Cl.uint(failId)], user1);
+
+      // Complete and withdraw one habit (becomes an eligible claimant).
+      const completed = createHabit(user1, "Claim eligible", MIN_STAKE);
+      const completedId = Number((completed.result as any).value.value);
+      simnet.mineEmptyBlocks(MIN_CHECK_IN_INTERVAL);
+      for (let i = 0; i < 7; i++) { checkIn(user1, completedId); simnet.mineEmptyBlocks(120); }
+      withdrawStake(user1, completedId);
+
+      expect(getUnclaimedCompletedHabits().result).toEqual(Cl.ok(Cl.uint(1)));
+
+      const claim = simnet.callPublicFn("habit-tracker-v2", "claim-bonus", [Cl.uint(completedId)], user1);
+      expect(claim.result).toEqual(Cl.ok(Cl.uint(MIN_STAKE)));
+      expect(getUnclaimedCompletedHabits().result).toEqual(Cl.ok(Cl.uint(0)));
+    });
+
   });
 
   describe("read-only functions", () => {

--- a/tests/habit-tracker.test.ts
+++ b/tests/habit-tracker.test.ts
@@ -458,8 +458,8 @@ describe("AhhbitTracker Contract", () => {
       expect((bonus1 - bonus2) / bonus1).toBeLessThan(0.02);
     });
 
-    it("should cap bonus at MAX-BONUS-AMOUNT (1 STX)", () => {
-      // Fund pool with two large slashed stakes to exceed 100 STX
+    it("should distribute full pool when only one claimant is eligible", () => {
+      // Fund pool with two large slashed stakes.
       const fail1 = createHabit(user2, "Big stake 1", MAX_STAKE_AMOUNT);
       const fid1 = Number((fail1.result as any).value.value);
       simnet.mineEmptyBlocks(MIN_CHECK_IN_INTERVAL);
@@ -473,7 +473,7 @@ describe("AhhbitTracker Contract", () => {
       checkIn(user3, fid2);
       simnet.mineEmptyBlocks(150);
       simnet.callPublicFn("habit-tracker-v2", "slash-habit", [Cl.uint(fid2)], user1);
-      // Pool = 200 STX. 1% = 2 STX > MAX-BONUS-AMOUNT (1 STX)
+      // Pool = 200 STX and user1 is the only eligible claimant.
 
       // User1 completes a habit and claims
       const h1 = createHabit(user1, "Capped habit", MIN_STAKE);
@@ -483,8 +483,7 @@ describe("AhhbitTracker Contract", () => {
       withdrawStake(user1, cid);
 
       const result = simnet.callPublicFn("habit-tracker-v2", "claim-bonus", [Cl.uint(cid)], user1);
-      // Should be capped at 1 STX = 1,000,000 microSTX
-      expect(result.result).toEqual(Cl.ok(Cl.uint(1_000_000)));
+      expect(result.result).toEqual(Cl.ok(Cl.uint(MAX_STAKE_AMOUNT * 2)));
     });
 
     it("should reject bonus claim by non-owner", () => {

--- a/tests/habit-tracker.test.ts
+++ b/tests/habit-tracker.test.ts
@@ -532,6 +532,42 @@ describe("AhhbitTracker Contract", () => {
       expect(getUnclaimedCompletedHabits().result).toEqual(Cl.ok(Cl.uint(0)));
     });
 
+    it("should report estimated bonus share from pool and claimant count", () => {
+      // Fund a 0.06 STX pool.
+      const failing = createHabit(user3, "Pool source", MIN_STAKE * 3);
+      const failingId = Number((failing.result as any).value.value);
+      simnet.mineEmptyBlocks(MIN_CHECK_IN_INTERVAL);
+      checkIn(user3, failingId);
+      simnet.mineEmptyBlocks(150);
+      simnet.callPublicFn("habit-tracker-v2", "slash-habit", [Cl.uint(failingId)], user1);
+
+      // Prepare two eligible claimants.
+      const h1 = createHabit(user1, "Estimator A", MIN_STAKE);
+      const id1 = Number((h1.result as any).value.value);
+      simnet.mineEmptyBlocks(MIN_CHECK_IN_INTERVAL);
+      for (let i = 0; i < 7; i++) { checkIn(user1, id1); simnet.mineEmptyBlocks(120); }
+      withdrawStake(user1, id1);
+
+      const h2 = createHabit(user2, "Estimator B", MIN_STAKE);
+      const id2 = Number((h2.result as any).value.value);
+      simnet.mineEmptyBlocks(MIN_CHECK_IN_INTERVAL);
+      for (let i = 0; i < 7; i++) { checkIn(user2, id2); simnet.mineEmptyBlocks(120); }
+      withdrawStake(user2, id2);
+
+      // 60,000 / 2 claimants => 30,000 estimated bonus share.
+      expect(getEstimatedBonusShare().result).toEqual(Cl.ok(Cl.uint(MIN_STAKE + (MIN_STAKE / 2))));
+
+      const firstClaim = simnet.callPublicFn("habit-tracker-v2", "claim-bonus", [Cl.uint(id1)], user1);
+      expect(firstClaim.result).toEqual(Cl.ok(Cl.uint(MIN_STAKE + (MIN_STAKE / 2))));
+
+      // Remaining pool = 30,000 with one claimant left => 30,000.
+      expect(getEstimatedBonusShare().result).toEqual(Cl.ok(Cl.uint(MIN_STAKE + (MIN_STAKE / 2))));
+
+      const secondClaim = simnet.callPublicFn("habit-tracker-v2", "claim-bonus", [Cl.uint(id2)], user2);
+      expect(secondClaim.result).toEqual(Cl.ok(Cl.uint(MIN_STAKE + (MIN_STAKE / 2))));
+      expect(getEstimatedBonusShare().result).toEqual(Cl.ok(Cl.uint(0)));
+    });
+
   });
 
   describe("read-only functions", () => {


### PR DESCRIPTION
## Summary
Replace bonus claim payout logic with share-based distribution using current pool balance and unclaimed completed claimant count.
- Add read-only contract endpoints for unclaimed claimant count and estimated next bonus share.
- Update web and mobile clients to consume and display contract-driven bonus share estimates.
- Refresh contract, API, architecture, and top-level docs to match the implemented distribution behavior.
## Validation
- clarinet check passes (warnings only).
- Habit tracker contract tests pass: 60/60.
- Frontend targeted tests pass: 22/22 across contract service, habit card, and hook sync coverage.
## Note
Mobile typecheck currently reports two nullability errors in an existing wallet interaction sync area that is outside this bonus distribution implementation.
