### PR TITLE
Add biometric protection for sensitive mobile actions

### DIFF
--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -87,6 +87,10 @@ Security guidelines for AhhbitTracker developers and users.
 
 4. **Confirm network** (mainnet vs testnet)
 
+### Mobile Biometric Protection
+
+- Sensitive mobile actions such as create habit, check-in, withdraw, claim bonus, save address, and clear address require biometric confirmation when the device supports it
+
 **Never sign:**
 - Transactions from unknown sources
 - Requests for full wallet access

--- a/docs/USER_GUIDE.md
+++ b/docs/USER_GUIDE.md
@@ -42,6 +42,8 @@ Successful users can claim bonuses from the forfeited pool created by users who 
 4. Set your stake amount (0.02 to 100 STX)
 5. Confirm the transaction
 
+On mobile, the app will ask for biometric confirmation before opening the wallet prompt when the device supports it.
+
 **Transaction cost:** ~0.15-0.25 STX
 
 ### Daily Check-ins
@@ -50,6 +52,8 @@ Successful users can claim bonuses from the forfeited pool created by users who 
 2. Use the Dashboard "Run Daily Check-In" action to submit all eligible habits, or click "Check In" on a single habit
 3. Confirm each wallet prompt
 4. Watch the transaction tracker for pending, confirmed, or failed on-chain status
+
+On mobile, check-in previews and wallet handoff are protected by biometric confirmation on supported devices.
 
 **Transaction cost:** ~0.10-0.20 STX per check-in
 
@@ -60,6 +64,8 @@ After completing 7+ consecutive check-ins:
 1. Click "Withdraw Stake" on your completed habit
 2. Confirm the transaction
 3. Your stake is returned to your wallet
+
+On mobile, withdrawal and bonus claim actions also require biometric confirmation when available.
 
 **Transaction cost:** ~0.15-0.25 STX
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -39,6 +39,7 @@ mobile/src/
 - Wallet handoffs are modeled as session-scoped deep links, not persisted account state
 - Legacy paths in `src/components`, `src/services`, etc. are maintained as re-export shims for compatibility
 - Shared UI primitives keep card surfaces, action buttons, and metric rows visually aligned without duplicating styles
+- Sensitive mobile actions prompt for device biometrics when available before generating previews or clearing tracked account state
 
 ## Global State Management
 

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -150,7 +150,15 @@ const config: ExpoConfig = {
     edgeToEdgeEnabled: true,
     predictiveBackGestureEnabled: false,
   },
-  plugins: ['expo-notifications'],
+  plugins: [
+    [
+      'expo-local-authentication',
+      {
+        faceIDPermission: 'Allow AhhbitTracker Mobile to use Face ID for protected actions.',
+      },
+    ],
+    'expo-notifications',
+  ],
   extra: {
     appStage: networkConfig.appStage,
     contractAddress: networkConfig.contract.contractAddress,

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -26,7 +26,15 @@
       "edgeToEdgeEnabled": true,
       "predictiveBackGestureEnabled": false
     },
-    "plugins": ["expo-notifications"],
+    "plugins": [
+      [
+        "expo-local-authentication",
+        {
+          "faceIDPermission": "Allow AhhbitTracker Mobile to use Face ID for protected actions."
+        }
+      ],
+      "expo-notifications"
+    ],
     "extra": {
       "appStage": "production",
       "contractAddress": "SP1N3809W9CBWWX04KN3TCQHP8A9GN520BD4JMP8Z",

--- a/mobile/package-lock.json
+++ b/mobile/package-lock.json
@@ -21,6 +21,7 @@
         "expo-clipboard": "^55.0.12",
         "expo-constants": "~18.0.10",
         "expo-linking": "^55.0.11",
+        "expo-local-authentication": "~17.0.8",
         "expo-notifications": "~0.32.16",
         "expo-status-bar": "~3.0.9",
         "react": "19.1.0",
@@ -5070,6 +5071,18 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/expo-local-authentication": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/expo-local-authentication/-/expo-local-authentication-17.0.8.tgz",
+      "integrity": "sha512-Q5fXHhu6w3pVPlFCibU72SYIAN+9wX7QpFn9h49IUqs0Equ44QgswtGrxeh7fdnDqJrrYGPet5iBzjnE70uolA==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-modules-autolinking": {

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -25,6 +25,7 @@
     "expo-clipboard": "^55.0.12",
     "expo-constants": "~18.0.10",
     "expo-linking": "^55.0.11",
+    "expo-local-authentication": "~17.0.8",
     "expo-notifications": "~0.32.16",
     "expo-status-bar": "~3.0.9",
     "react": "19.1.0",

--- a/mobile/src/app/screens/AccountScreen.tsx
+++ b/mobile/src/app/screens/AccountScreen.tsx
@@ -4,6 +4,7 @@ import { useAddressState } from '@/app/state';
 import { useState } from 'react';
 import { ActionButton, Card, EmptyState, InteractionStatusBanner, MetricRow, Screen, SectionHeader } from '@/shared/components';
 import { useInteractionStatus } from '@/shared/hooks/useInteractionStatus';
+import { useProtectedAction } from '@/shared/hooks/useProtectedAction';
 import { formatAddress } from '@/shared/utils';
 import { spacing } from '@/shared/theme';
 
@@ -12,6 +13,7 @@ export function AccountScreen() {
   const [isOpeningExplorer, setIsOpeningExplorer] = useState(false);
   const [isClearingAddress, setIsClearingAddress] = useState(false);
   const { status, showError, showSuccess } = useInteractionStatus();
+  const { runProtectedAction } = useProtectedAction();
 
   const openExplorer = async () => {
     if (!activeAddress) {
@@ -36,7 +38,7 @@ export function AccountScreen() {
     setIsClearingAddress(true);
 
     try {
-      await clearAddress();
+      await runProtectedAction('clear-address', () => clearAddress());
       showSuccess('Saved address cleared.');
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to clear saved address.';

--- a/mobile/src/app/screens/CreateHabitScreen.tsx
+++ b/mobile/src/app/screens/CreateHabitScreen.tsx
@@ -7,6 +7,7 @@ import {
   CreateHabitPreviewCard,
 } from '@/features/transactions';
 import { ActionButton, Screen, SectionHeader } from '@/shared/components';
+import { useProtectedAction } from '@/shared/hooks/useProtectedAction';
 import { toMicroSTX } from '@/shared/utils';
 import { spacing } from '@/shared/theme';
 
@@ -15,15 +16,17 @@ type CreateHabitScreenProps = RootStackScreenProps<'CreateHabit'>;
 export function CreateHabitScreen({ navigation }: CreateHabitScreenProps) {
   const { activeAddress } = useAddressState();
   const { setPreview } = usePreviewState();
+  const { runProtectedAction } = useProtectedAction();
 
   const handleCreatePreview = async (name: string, stakeAmountStx: number) => {
     if (!activeAddress) {
       throw new Error('Save a Stacks address before generating a create-habit preview.');
     }
 
-    setPreview(buildCreateHabitPreview(activeAddress, name, toMicroSTX(stakeAmountStx)));
-
-    navigation.navigate('MainTabs', { screen: MAIN_TAB_ROUTES.Preview });
+    await runProtectedAction('create-habit', () => {
+      setPreview(buildCreateHabitPreview(activeAddress, name, toMicroSTX(stakeAmountStx)));
+      navigation.navigate('MainTabs', { screen: MAIN_TAB_ROUTES.Preview });
+    });
   };
 
   return (

--- a/mobile/src/app/screens/DashboardScreen.tsx
+++ b/mobile/src/app/screens/DashboardScreen.tsx
@@ -1,8 +1,6 @@
 import { StyleSheet, View } from 'react-native';
 import { useAddressState, usePreviewState } from '@/app/state';
-import {
-  AddressInputCard,
-} from '@/features/address';
+import { AddressInputCard } from '@/features/address';
 import {
   HabitList,
   useCurrentBlockQuery,
@@ -20,13 +18,14 @@ import {
   TransactionPreviewPanel,
 } from '@/features/transactions';
 import { Card, EmptyState, LoadingState, MetricRow, Screen, SectionHeader } from '@/shared/components';
+import { useProtectedAction } from '@/shared/hooks/useProtectedAction';
 import { toMicroSTX } from '@/shared/utils';
 import { spacing } from '@/shared/theme';
-
 
 export function DashboardScreen() {
   const { activeAddress, isHydrating, setAddress, clearAddress } = useAddressState();
   const { preview, setPreview } = usePreviewState();
+  const { runProtectedAction } = useProtectedAction();
 
   const habitsQuery = useUserHabitsQuery(activeAddress);
   const currentBlockQuery = useCurrentBlockQuery();
@@ -38,20 +37,28 @@ export function DashboardScreen() {
       throw new Error('Save a Stacks address before generating a create-habit preview.');
     }
 
-    const stakeAmountMicroStx = toMicroSTX(stakeAmountStx);
-    setPreview(buildCreateHabitPreview(activeAddress, name, stakeAmountMicroStx));
+    await runProtectedAction('create-habit', () => {
+      const stakeAmountMicroStx = toMicroSTX(stakeAmountStx);
+      setPreview(buildCreateHabitPreview(activeAddress, name, stakeAmountMicroStx));
+    });
   };
 
   const handleCheckInPreview = async (habitId: number) => {
-    setPreview(buildCheckInPreview(habitId));
+    await runProtectedAction('check-in', () => {
+      setPreview(buildCheckInPreview(habitId));
+    });
   };
 
   const handleWithdrawPreview = async (habitId: number, stakeAmount: number) => {
-    setPreview(buildWithdrawStakePreview(habitId, stakeAmount));
+    await runProtectedAction('withdraw-stake', () => {
+      setPreview(buildWithdrawStakePreview(habitId, stakeAmount));
+    });
   };
 
   const handleClaimPreview = async (habitId: number) => {
-    setPreview(buildClaimBonusPreview(habitId));
+    await runProtectedAction('claim-bonus', () => {
+      setPreview(buildClaimBonusPreview(habitId));
+    });
   };
 
   if (isHydrating) {
@@ -90,9 +97,7 @@ export function DashboardScreen() {
         <EmptyState message="Save a Stacks address to load habits and stats." />
       )}
 
-      {activeAddress ? (
-        <CreateHabitPreviewCard onPreview={handleCreatePreview} />
-      ) : null}
+      {activeAddress ? <CreateHabitPreviewCard onPreview={handleCreatePreview} /> : null}
 
       <View style={styles.sectionSpacing}>
         <SectionHeader title="Habits" subtitle="Generate check-in, withdraw, or claim previews" />

--- a/mobile/src/app/screens/HabitDetailsScreen.tsx
+++ b/mobile/src/app/screens/HabitDetailsScreen.tsx
@@ -11,6 +11,7 @@ import {
 } from '@/features/transactions';
 import { ActionButton, Card, EmptyState, ErrorState, InteractionStatusBanner, LoadingState, MetricRow, Screen, SectionHeader } from '@/shared/components';
 import { useInteractionStatus } from '@/shared/hooks/useInteractionStatus';
+import { useProtectedAction } from '@/shared/hooks/useProtectedAction';
 import {
   canWithdrawHabit,
   canSubmitMobileDailyCheckIn,
@@ -28,6 +29,7 @@ export function HabitDetailsScreen({ route, navigation }: HabitDetailsScreenProp
   const { habitId } = route.params;
   const { activeAddress } = useAddressState();
   const { setPreview } = usePreviewState();
+  const { runProtectedAction } = useProtectedAction();
   const [pendingAction, setPendingAction] = useState<'check-in' | 'withdraw' | 'claim' | null>(null);
   const { status, showError, showSuccess } = useInteractionStatus();
 
@@ -77,8 +79,10 @@ export function HabitDetailsScreen({ route, navigation }: HabitDetailsScreenProp
       throw new Error('This habit is not eligible for check-in yet.');
     }
 
-    setPreview(buildCheckInPreview(habit.habitId));
-    navigateToPreview();
+    return runProtectedAction('check-in', () => {
+      setPreview(buildCheckInPreview(habit.habitId));
+      navigateToPreview();
+    });
   };
 
   const handleWithdrawPreview = () => {
@@ -86,24 +90,28 @@ export function HabitDetailsScreen({ route, navigation }: HabitDetailsScreenProp
       throw new Error('This habit is not eligible for withdrawal yet.');
     }
 
-    setPreview(buildWithdrawStakePreview(habit.habitId, habit.stakeAmount));
-    navigateToPreview();
+    return runProtectedAction('withdraw-stake', () => {
+      setPreview(buildWithdrawStakePreview(habit.habitId, habit.stakeAmount));
+      navigateToPreview();
+    });
   };
 
   const handleClaimPreview = () => {
-    setPreview(buildClaimBonusPreview(habit.habitId));
-    navigateToPreview();
+    return runProtectedAction('claim-bonus', () => {
+      setPreview(buildClaimBonusPreview(habit.habitId));
+      navigateToPreview();
+    });
   };
 
   const runAction = async (
     action: 'check-in' | 'withdraw' | 'claim',
-    callback: () => void,
+    callback: () => Promise<void> | void,
     successMessage: string,
   ) => {
     setPendingAction(action);
 
     try {
-      callback();
+      await callback();
       showSuccess(successMessage);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to generate preview.';

--- a/mobile/src/app/screens/HabitsScreen.tsx
+++ b/mobile/src/app/screens/HabitsScreen.tsx
@@ -14,6 +14,7 @@ import {
   buildWithdrawStakePreview,
 } from '@/features/transactions';
 import { ActionButton, EmptyState, ErrorState, LoadingState, Screen, SectionHeader } from '@/shared/components';
+import { useProtectedAction } from '@/shared/hooks/useProtectedAction';
 import { spacing } from '@/shared/theme';
 
 type HabitsScreenProps = MainTabScreenProps<'Habits'>;
@@ -21,6 +22,7 @@ type HabitsScreenProps = MainTabScreenProps<'Habits'>;
 export function HabitsScreen({ navigation }: HabitsScreenProps) {
   const { activeAddress } = useAddressState();
   const { setPreview } = usePreviewState();
+  const { runProtectedAction } = useProtectedAction();
   const habitsQuery = useUserHabitsQuery(activeAddress);
   const currentBlockQuery = useCurrentBlockQuery();
 
@@ -29,18 +31,24 @@ export function HabitsScreen({ navigation }: HabitsScreenProps) {
   };
 
   const handleCheckInPreview = async (habitId: number) => {
-    setPreview(buildCheckInPreview(habitId));
-    openPreviewTab();
+    await runProtectedAction('check-in', () => {
+      setPreview(buildCheckInPreview(habitId));
+      openPreviewTab();
+    });
   };
 
   const handleWithdrawPreview = async (habitId: number, stakeAmount: number) => {
-    setPreview(buildWithdrawStakePreview(habitId, stakeAmount));
-    openPreviewTab();
+    await runProtectedAction('withdraw-stake', () => {
+      setPreview(buildWithdrawStakePreview(habitId, stakeAmount));
+      openPreviewTab();
+    });
   };
 
   const handleClaimPreview = async (habitId: number) => {
-    setPreview(buildClaimBonusPreview(habitId));
-    openPreviewTab();
+    await runProtectedAction('claim-bonus', () => {
+      setPreview(buildClaimBonusPreview(habitId));
+      openPreviewTab();
+    });
   };
 
   return (

--- a/mobile/src/features/address/components/AddressInputCard.tsx
+++ b/mobile/src/features/address/components/AddressInputCard.tsx
@@ -7,6 +7,8 @@ import {
   View,
 } from 'react-native';
 import { ActionButton, Card } from '@/shared/components';
+import { useProtectedAction } from '@/shared/hooks/useProtectedAction';
+import { validateStacksAddress } from '@/shared/utils';
 import { palette, radius, spacing, typography } from '@/shared/theme';
 
 interface AddressInputCardProps {
@@ -25,6 +27,7 @@ export function AddressInputCard({
   const [isClearing, setIsClearing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState<string | null>(null);
+  const { runProtectedAction } = useProtectedAction();
 
   const pending = isSaving || isClearing;
 
@@ -33,12 +36,21 @@ export function AddressInputCard({
   }, [initialValue]);
 
   const handleSave = async () => {
+    const normalizedValue = value.trim();
+    const validationError = validateStacksAddress(normalizedValue);
+
+    if (validationError) {
+      setError(validationError);
+      setSuccess(null);
+      return;
+    }
+
     setIsSaving(true);
     setError(null);
     setSuccess(null);
 
     try {
-      await onSubmit(value);
+      await runProtectedAction('save-address', () => onSubmit(normalizedValue));
       setSuccess('Address saved successfully.');
     } catch (submissionError) {
       setError(
@@ -58,7 +70,7 @@ export function AddressInputCard({
     setSuccess(null);
 
     try {
-      await onClear();
+      await runProtectedAction('clear-address', () => onClear());
       setValue('');
       setSuccess('Address cleared.');
     } catch (clearError) {

--- a/mobile/src/shared/hooks/useProtectedAction.ts
+++ b/mobile/src/shared/hooks/useProtectedAction.ts
@@ -1,0 +1,15 @@
+import { useCallback } from 'react';
+import { authenticateBiometricAction } from '@/shared/security/biometricAuthentication';
+import type { BiometricProtectedAction } from '@/shared/security/biometrics';
+
+export function useProtectedAction() {
+  const runProtectedAction = useCallback(
+    async <T>(action: BiometricProtectedAction, callback: () => Promise<T> | T): Promise<T> => {
+      await authenticateBiometricAction(action);
+      return callback();
+    },
+    [],
+  );
+
+  return { runProtectedAction };
+}

--- a/mobile/src/shared/security/biometricAuthentication.ts
+++ b/mobile/src/shared/security/biometricAuthentication.ts
@@ -1,0 +1,37 @@
+import * as LocalAuthentication from 'expo-local-authentication';
+import { Platform } from 'react-native';
+import {
+  getBiometricPromptMessage,
+  isBiometricAuthSupported,
+  mapBiometricError,
+  type BiometricProtectedAction,
+} from './biometrics';
+
+export async function authenticateBiometricAction(action: BiometricProtectedAction): Promise<void> {
+  if (Platform.OS === 'web') {
+    return;
+  }
+
+  const [hasHardware, isEnrolled] = await Promise.all([
+    LocalAuthentication.hasHardwareAsync(),
+    LocalAuthentication.isEnrolledAsync(),
+  ]);
+
+  if (!isBiometricAuthSupported(Platform.OS, hasHardware, isEnrolled)) {
+    return;
+  }
+
+  const result = await LocalAuthentication.authenticateAsync({
+    promptMessage: getBiometricPromptMessage(action),
+    promptDescription: 'Confirm this sensitive account action.',
+    cancelLabel: 'Cancel',
+    fallbackLabel: 'Use passcode',
+    biometricsSecurityLevel: 'strong',
+    disableDeviceFallback: false,
+    requireConfirmation: true,
+  });
+
+  if (!result.success) {
+    throw new Error(mapBiometricError(result.error));
+  }
+}

--- a/mobile/src/shared/security/biometrics.ts
+++ b/mobile/src/shared/security/biometrics.ts
@@ -1,0 +1,48 @@
+export type BiometricProtectedAction =
+  | 'create-habit'
+  | 'check-in'
+  | 'withdraw-stake'
+  | 'claim-bonus'
+  | 'save-address'
+  | 'clear-address';
+
+const BIOMETRIC_PROMPTS: Record<BiometricProtectedAction, string> = {
+  'create-habit': 'Approve this create-habit preview.',
+  'check-in': 'Approve this check-in preview.',
+  'withdraw-stake': 'Approve this withdrawal preview.',
+  'claim-bonus': 'Approve this bonus claim preview.',
+  'save-address': 'Approve saving this tracked address.',
+  'clear-address': 'Approve clearing this tracked address.',
+};
+
+export function getBiometricPromptMessage(action: BiometricProtectedAction): string {
+  return BIOMETRIC_PROMPTS[action];
+}
+
+export function isBiometricAuthSupported(
+  platform: string,
+  hasHardware: boolean,
+  isEnrolled: boolean,
+): boolean {
+  return platform !== 'web' && hasHardware && isEnrolled;
+}
+
+export function mapBiometricError(error: string | undefined): string {
+  switch (error) {
+    case 'not_enrolled':
+      return 'Set up Face ID, Touch ID, or fingerprint authentication on this device to continue.';
+    case 'passcode_not_set':
+      return 'Set a device passcode or biometric lock to continue.';
+    case 'lockout':
+      return 'Biometric authentication is locked. Try again later.';
+    case 'user_cancel':
+    case 'app_cancel':
+    case 'system_cancel':
+    case 'user_fallback':
+      return 'Biometric authentication was cancelled.';
+    case 'not_available':
+      return 'Biometric authentication is not available on this device.';
+    default:
+      return 'Biometric authentication failed.';
+  }
+}

--- a/tests/mobile-biometric.test.ts
+++ b/tests/mobile-biometric.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getBiometricPromptMessage,
+  isBiometricAuthSupported,
+  mapBiometricError,
+} from '../mobile/src/shared/security/biometrics';
+
+describe('mobile biometric helpers', () => {
+  it('maps protected actions to prompt copy', () => {
+    expect(getBiometricPromptMessage('create-habit')).toBe('Approve this create-habit preview.');
+    expect(getBiometricPromptMessage('check-in')).toBe('Approve this check-in preview.');
+    expect(getBiometricPromptMessage('withdraw-stake')).toBe('Approve this withdrawal preview.');
+    expect(getBiometricPromptMessage('claim-bonus')).toBe('Approve this bonus claim preview.');
+    expect(getBiometricPromptMessage('save-address')).toBe('Approve saving this tracked address.');
+    expect(getBiometricPromptMessage('clear-address')).toBe('Approve clearing this tracked address.');
+  });
+
+  it('treats web as unsupported and native enrolled hardware as supported', () => {
+    expect(isBiometricAuthSupported('web', true, true)).toBe(false);
+    expect(isBiometricAuthSupported('ios', true, true)).toBe(true);
+    expect(isBiometricAuthSupported('android', true, false)).toBe(false);
+  });
+
+  it('maps biometric errors to user-facing copy', () => {
+    expect(mapBiometricError('not_enrolled')).toContain('Face ID');
+    expect(mapBiometricError('passcode_not_set')).toContain('device passcode');
+    expect(mapBiometricError('lockout')).toContain('locked');
+    expect(mapBiometricError('user_cancel')).toBe('Biometric authentication was cancelled.');
+    expect(mapBiometricError('not_available')).toBe('Biometric authentication is not available on this device.');
+    expect(mapBiometricError(undefined)).toBe('Biometric authentication failed.');
+  });
+});


### PR DESCRIPTION
Summary
- Require biometrics for create habit, check-in, withdraw, claim, and saved-address actions where supported.
- Add Expo LocalAuthentication config, shared helpers, and unit coverage for the prompt mapping.

Verification
- npm test -- tests/mobile-biometric.test.ts
- cd mobile && npm run typecheck