### PR TITLE
Add cross-platform analytics event tracking for user behavior insights

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -76,6 +76,46 @@ The application now uses layered caching and transaction-aware invalidation to r
 - Wallet interaction synchronization now invalidates both query keys and data-layer cache namespaces when writes confirm, ensuring the next UI read rehydrates from chain-backed sources.
 - Address transitions in app state now clear address-scoped caches to prevent cross-account data bleed.
 
+## Analytics and Event Tracking
+
+AhhbitTracker now includes first-party analytics event tracking in both frontend and mobile clients.
+
+### Design goals
+
+- Capture product behavior signals (navigation, wallet lifecycle, habit actions, notification controls) without leaking sensitive wallet or transaction details.
+- Keep analytics transport optional and environment-driven.
+- Protect user privacy by hashing wallet addresses and truncating error payloads.
+
+### Frontend implementation
+
+- Analytics lives under `frontend/src/analytics` with a typed event contract, payload sanitizer, and batched transport client.
+- Route and app-load events are emitted from `App.tsx`.
+- Wallet, create-habit, and habit action events are emitted from existing state/action boundaries (`WalletContext`, `HabitForm`, `HabitCard`, `useHabits`).
+- Dispatch uses `sendBeacon` when available and falls back to `fetch` with `keepalive`.
+
+### Mobile implementation
+
+- Analytics lives under `mobile/src/analytics` with typed events, privacy helpers, and a queued HTTP transport.
+- App lifecycle and navigation events are emitted from `AppRoot` and `AppNavigation`.
+- Address lifecycle, preview generation, wallet transaction outcomes, account explorer actions, and notification toggles are instrumented across existing screen/context boundaries.
+- Queue flush is triggered on interval and when app state leaves `active`.
+
+### Runtime configuration
+
+Frontend variables:
+
+- `VITE_ANALYTICS_ENABLED` (default `true`)
+- `VITE_ANALYTICS_ENDPOINT` (optional)
+- `VITE_ANALYTICS_WRITE_KEY` (optional)
+
+Mobile variables:
+
+- `EXPO_PUBLIC_ANALYTICS_ENABLED` (default `true`)
+- `EXPO_PUBLIC_ANALYTICS_ENDPOINT` (optional)
+- `EXPO_PUBLIC_ANALYTICS_WRITE_KEY` (optional)
+
+When endpoint values are unset, events stay in local in-memory queues and no network transmission occurs.
+
 ### Batch automation strategy
 
 - The batch executor now caches frequently repeated read-only calls (current block, user habits, habit lookups) during a run.

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -42,6 +42,9 @@ npm run dev                  # → http://localhost:3000
 | `VITE_STACKS_API_URL` | stage-based | Stacks API base URL used by the dev proxy |
 | `VITE_CONTRACT_ADDRESS` | `SP1N3809...` | Contract principal |
 | `VITE_CONTRACT_NAME` | `habit-tracker-v2` | Contract name |
+| `VITE_ANALYTICS_ENABLED` | `true` | Enable or disable frontend analytics emission |
+| `VITE_ANALYTICS_ENDPOINT` | _(unset)_ | Optional analytics ingestion endpoint |
+| `VITE_ANALYTICS_WRITE_KEY` | _(unset)_ | Optional ingestion auth key sent as `X-Analytics-Key` |
 
 Use stage templates for safer setup:
 
@@ -81,3 +84,4 @@ src/
 - **Dev proxy** — In development, Vite proxies `/api/stacks/*` to `https://api.mainnet.hiro.so` to avoid CORS
 - **Production** — Uses `STACKS_MAINNET` from `@stacks/network` directly (no proxy needed)
 - **Create habit flow** — The habit form enforces the contract's 0.02-100 STX stake range and 50-character name limit before submitting a `create-habit` call
+- **Analytics tracking** — Emits typed events for app load, route views, wallet lifecycle, create-habit flow, individual habit actions, and daily check-in batch runs

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { lazy, Suspense, useMemo } from 'react';
+import { lazy, Suspense, useEffect, useMemo, useRef } from 'react';
 import { emitRateLimitEvent } from './utils/rateLimitEvents';
 import { WalletProvider, useWallet } from './context/WalletContext';
 import { TransactionProvider } from './context/TransactionContext';
@@ -16,6 +16,7 @@ import { LongestStreakBanner } from './components/LongestStreakBanner';
 import { useHabits } from './hooks/useHabits';
 import { DashboardSkeleton } from './components/Skeletons';
 import { useHashRoute } from './hooks/useHashRoute';
+import { trackEvent } from './analytics';
 import './styles/global.css';
 
 // Code-split route-level components
@@ -69,6 +70,26 @@ function AppContent() {
     isRunningDailyCheckIn,
   } = useHabits();
   const { route } = useHashRoute();
+  const trackedAppLoadRef = useRef(false);
+
+  useEffect(() => {
+    if (trackedAppLoadRef.current) {
+      return;
+    }
+
+    trackedAppLoadRef.current = true;
+    trackEvent('app_loaded', {
+      route,
+      source: 'frontend',
+    });
+  }, [route]);
+
+  useEffect(() => {
+    trackEvent('route_viewed', {
+      route,
+      source: 'frontend',
+    });
+  }, [route]);
 
   const longestStreakData = useMemo(() => {
     return habits.reduce(

--- a/frontend/src/__tests__/analyticsPrivacy.test.ts
+++ b/frontend/src/__tests__/analyticsPrivacy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { anonymizeAddress, sanitizePayload } from '../analytics/privacy';
+
+describe('analytics privacy helpers', () => {
+  it('hashes wallet addresses deterministically', () => {
+    const address = 'SP1N3809W9CBWWX04KN3TCQHP8A9GN520BD4JMP8Z';
+    const first = anonymizeAddress(address);
+    const second = anonymizeAddress(address);
+
+    expect(first).toBeDefined();
+    expect(first).toBe(second);
+    expect(first).not.toContain('SP1N3809');
+  });
+
+  it('drops tx ids and truncates long errors', () => {
+    const payload = sanitizePayload({
+      txId: '0xabc123',
+      errorMessage: 'x'.repeat(200),
+      habitId: 4,
+    });
+
+    expect(payload?.txId).toBeUndefined();
+    expect(payload?.habitId).toBe(4);
+    expect(payload?.errorMessage?.length).toBeLessThanOrEqual(160);
+  });
+});

--- a/frontend/src/__tests__/uiPrimitives.test.tsx
+++ b/frontend/src/__tests__/uiPrimitives.test.tsx
@@ -16,11 +16,11 @@ describe('SurfaceCard', () => {
 
 describe('ActionButton', () => {
   it('renders loading copy and disables interaction', () => {
-    render(<ActionButton label="Save" loading loadingLabel="Saving" />);
+    render(<ActionButton isLoading>Save</ActionButton>);
 
     const button = screen.getByRole('button');
     expect(button).toHaveProperty('disabled', true);
-    expect(screen.getByText('Saving')).toBeDefined();
+    expect(screen.getByText('Loading…')).toBeDefined();
   });
 });
 

--- a/frontend/src/__tests__/useHabits.sync.test.tsx
+++ b/frontend/src/__tests__/useHabits.sync.test.tsx
@@ -54,6 +54,8 @@ vi.mock('../services/contractService', () => ({
     readPoolBalance: vi.fn().mockResolvedValue(0),
     readEstimatedBonusShare: vi.fn().mockResolvedValue(0),
     readUnclaimedCompletedHabits: vi.fn().mockResolvedValue(0),
+    invalidateAddressReadCache: vi.fn(),
+    invalidatePoolReadCache: vi.fn(),
     createHabit: vi.fn(),
     checkIn: vi.fn(),
     withdrawStake: vi.fn(),

--- a/frontend/src/analytics/client.ts
+++ b/frontend/src/analytics/client.ts
@@ -1,0 +1,123 @@
+import type { AnalyticsEvent, AnalyticsEventPayload } from './events';
+import { sanitizePayload } from './privacy';
+
+interface AnalyticsEnvelope {
+  event: AnalyticsEvent['event'];
+  payload?: AnalyticsEventPayload;
+  timestamp: string;
+  platform: 'web';
+  stage: string;
+  sessionId: string;
+}
+
+interface AnalyticsClientOptions {
+  endpoint?: string;
+  writeKey?: string;
+  enabled: boolean;
+  stage: string;
+  flushIntervalMs?: number;
+  maxQueueSize?: number;
+}
+
+const DEFAULT_FLUSH_INTERVAL_MS = 5_000;
+const DEFAULT_MAX_QUEUE_SIZE = 100;
+
+function createSessionId(): string {
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+}
+
+export function createAnalyticsClient(options: AnalyticsClientOptions) {
+  const queue: AnalyticsEnvelope[] = [];
+  const flushIntervalMs = options.flushIntervalMs ?? DEFAULT_FLUSH_INTERVAL_MS;
+  const maxQueueSize = options.maxQueueSize ?? DEFAULT_MAX_QUEUE_SIZE;
+  const sessionId = createSessionId();
+  let timerId: ReturnType<typeof setInterval> | null = null;
+  let isFlushing = false;
+
+  const shouldSend = options.enabled && Boolean(options.endpoint);
+
+  const flush = async () => {
+    if (!shouldSend || isFlushing || !queue.length) {
+      return;
+    }
+
+    isFlushing = true;
+    const batch = queue.splice(0, queue.length);
+
+    const body = JSON.stringify({
+      app: 'ahhbittracker-web',
+      events: batch,
+    });
+
+    try {
+      if (navigator.sendBeacon) {
+        const blob = new Blob([body], { type: 'application/json' });
+        const ok = navigator.sendBeacon(options.endpoint!, blob);
+        if (!ok) {
+          throw new Error('sendBeacon rejected payload');
+        }
+      } else {
+        await fetch(options.endpoint!, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            ...(options.writeKey ? { 'X-Analytics-Key': options.writeKey } : {}),
+          },
+          body,
+          keepalive: true,
+        });
+      }
+    } catch {
+      queue.unshift(...batch.slice(0, maxQueueSize));
+    } finally {
+      isFlushing = false;
+    }
+  };
+
+  const enqueue = (event: AnalyticsEvent['event'], payload?: AnalyticsEventPayload) => {
+    const sanitizedPayload = sanitizePayload(payload);
+
+    queue.push({
+      event,
+      payload: sanitizedPayload,
+      timestamp: new Date().toISOString(),
+      platform: 'web',
+      stage: options.stage,
+      sessionId,
+    });
+
+    if (queue.length > maxQueueSize) {
+      queue.splice(0, queue.length - maxQueueSize);
+    }
+  };
+
+  const start = () => {
+    if (timerId !== null) {
+      return;
+    }
+
+    timerId = setInterval(() => {
+      void flush();
+    }, flushIntervalMs);
+
+    window.addEventListener('beforeunload', () => {
+      void flush();
+    });
+  };
+
+  const stop = async () => {
+    if (timerId !== null) {
+      clearInterval(timerId);
+      timerId = null;
+    }
+
+    await flush();
+  };
+
+  return {
+    track: enqueue,
+    flush,
+    start,
+    stop,
+  };
+}

--- a/frontend/src/analytics/events.ts
+++ b/frontend/src/analytics/events.ts
@@ -1,0 +1,46 @@
+export type AnalyticsEventName =
+  | 'app_loaded'
+  | 'route_viewed'
+  | 'wallet_connect_started'
+  | 'wallet_connected'
+  | 'wallet_connect_cancelled'
+  | 'wallet_disconnect_clicked'
+  | 'wallet_disconnected'
+  | 'habit_create_submitted'
+  | 'habit_create_succeeded'
+  | 'habit_create_failed'
+  | 'habit_check_in_clicked'
+  | 'habit_check_in_succeeded'
+  | 'habit_check_in_failed'
+  | 'habit_withdraw_clicked'
+  | 'habit_withdraw_succeeded'
+  | 'habit_withdraw_failed'
+  | 'habit_claim_clicked'
+  | 'habit_claim_succeeded'
+  | 'habit_claim_failed'
+  | 'habit_finalize_clicked'
+  | 'habit_finalize_succeeded'
+  | 'habit_finalize_failed'
+  | 'daily_check_in_started'
+  | 'daily_check_in_completed';
+
+export interface AnalyticsEventPayload {
+  route?: string;
+  source?: string;
+  walletAddressHash?: string;
+  habitId?: number;
+  habitNameLength?: number;
+  stakeAmountMicroStx?: number;
+  functionName?: string;
+  txId?: string;
+  attempted?: number;
+  submitted?: number;
+  failed?: number;
+  errorCode?: string;
+  errorMessage?: string;
+}
+
+export interface AnalyticsEvent {
+  event: AnalyticsEventName;
+  payload?: AnalyticsEventPayload;
+}

--- a/frontend/src/analytics/index.ts
+++ b/frontend/src/analytics/index.ts
@@ -1,0 +1,26 @@
+import { createAnalyticsClient } from './client';
+import { anonymizeAddress } from './privacy';
+import type { AnalyticsEventName, AnalyticsEventPayload } from './events';
+
+const analyticsEnv = import.meta.env as Record<string, string | undefined>;
+const analyticsEndpoint = analyticsEnv.VITE_ANALYTICS_ENDPOINT?.trim();
+const analyticsWriteKey = analyticsEnv.VITE_ANALYTICS_WRITE_KEY?.trim();
+const analyticsEnabled = analyticsEnv.VITE_ANALYTICS_ENABLED !== 'false';
+const dntEnabled = typeof navigator !== 'undefined' && navigator.doNotTrack === '1';
+
+const analyticsClient = createAnalyticsClient({
+  endpoint: analyticsEndpoint,
+  writeKey: analyticsWriteKey,
+  enabled: analyticsEnabled && !dntEnabled,
+  stage: analyticsEnv.VITE_APP_STAGE ?? (import.meta.env.DEV ? 'development' : 'production'),
+});
+
+analyticsClient.start();
+
+export function trackEvent(event: AnalyticsEventName, payload?: AnalyticsEventPayload): void {
+  analyticsClient.track(event, payload);
+}
+
+export function toWalletAddressHash(address: string | null | undefined): string | undefined {
+  return anonymizeAddress(address);
+}

--- a/frontend/src/analytics/privacy.ts
+++ b/frontend/src/analytics/privacy.ts
@@ -1,0 +1,35 @@
+import type { AnalyticsEventPayload } from './events';
+
+function stableHash(input: string): string {
+  let hash = 5381;
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash * 33) ^ input.charCodeAt(index);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+function truncateErrorMessage(message: string): string {
+  return message.length > 160 ? `${message.slice(0, 157)}...` : message;
+}
+
+export function anonymizeAddress(address: string | null | undefined): string | undefined {
+  if (!address) {
+    return undefined;
+  }
+
+  return stableHash(address.toLowerCase());
+}
+
+export function sanitizePayload(payload?: AnalyticsEventPayload): AnalyticsEventPayload | undefined {
+  if (!payload) {
+    return undefined;
+  }
+
+  return {
+    ...payload,
+    txId: undefined,
+    errorMessage: payload.errorMessage ? truncateErrorMessage(payload.errorMessage) : undefined,
+  };
+}

--- a/frontend/src/components/HabitCard.tsx
+++ b/frontend/src/components/HabitCard.tsx
@@ -15,6 +15,7 @@ import {
   isEligibleForDailyCheckIn,
   isEligibleToWithdraw,
 } from '../utils/habitStatus';
+import { trackEvent } from '../analytics';
 
 interface HabitCardProps {
   habit: Habit;
@@ -52,11 +53,15 @@ export function HabitCard({ habit }: HabitCardProps) {
   const isOwnHabit = walletState.address?.toLowerCase() === habit.owner.toLowerCase();
 
   const handleCheckIn = async () => {
+    trackEvent('habit_check_in_clicked', { habitId: habit.habitId });
+
     try {
       await checkIn(habit.habitId);
+      trackEvent('habit_check_in_succeeded', { habitId: habit.habitId });
       showToast('Check-in signed! It will update once confirmed on-chain.', 'success');
     } catch (err: unknown) {
       const message = getErrorMessage(err);
+      trackEvent('habit_check_in_failed', { habitId: habit.habitId, errorMessage: message });
       if (message === 'Transaction cancelled') {
         showToast('Check-in was cancelled.', 'error');
       } else if (message.includes('u114') || message.includes('ERR-HABIT-AUTO-SLASHED')) {
@@ -68,14 +73,17 @@ export function HabitCard({ habit }: HabitCardProps) {
   };
 
   const handleWithdraw = () => {
+    trackEvent('habit_withdraw_clicked', { habitId: habit.habitId });
     setConfirmAction('withdraw');
   };
 
   const handleClaimBonus = () => {
+    trackEvent('habit_claim_clicked', { habitId: habit.habitId });
     setConfirmAction('claim');
   };
 
   const handleSlashHabit = () => {
+    trackEvent('habit_finalize_clicked', { habitId: habit.habitId });
     setConfirmAction('slash');
   };
 
@@ -85,16 +93,27 @@ export function HabitCard({ habit }: HabitCardProps) {
     try {
       if (action === 'withdraw') {
         await withdrawStake({ habitId: habit.habitId, stakeAmount: habit.stakeAmount });
+        trackEvent('habit_withdraw_succeeded', { habitId: habit.habitId });
         showToast('Withdrawal signed! Your STX will return once confirmed on-chain.', 'success');
       } else if (action === 'claim') {
         await claimBonus(habit.habitId);
+        trackEvent('habit_claim_succeeded', { habitId: habit.habitId });
         showToast('Bonus claim signed! It will arrive once confirmed on-chain.', 'success');
       } else if (action === 'slash') {
         await slashHabit(habit.habitId);
+        trackEvent('habit_finalize_succeeded', { habitId: habit.habitId });
         showToast('Habit finalized! Stake will be moved to the pool once confirmed on-chain.', 'success');
       }
     } catch (err: unknown) {
       const message = getErrorMessage(err);
+      if (action === 'withdraw') {
+        trackEvent('habit_withdraw_failed', { habitId: habit.habitId, errorMessage: message });
+      } else if (action === 'claim') {
+        trackEvent('habit_claim_failed', { habitId: habit.habitId, errorMessage: message });
+      } else if (action === 'slash') {
+        trackEvent('habit_finalize_failed', { habitId: habit.habitId, errorMessage: message });
+      }
+
       if (message === 'Transaction cancelled') {
         showToast('Transaction was cancelled.', 'error');
       } else {

--- a/frontend/src/components/HabitForm.tsx
+++ b/frontend/src/components/HabitForm.tsx
@@ -5,6 +5,7 @@ import { validateHabitName, validateStakeAmount } from '../utils/validation';
 import { toMicroSTX } from '../utils/formatting';
 import { MAX_HABIT_NAME_LENGTH, MAX_STAKE_AMOUNT, MIN_STAKE_AMOUNT } from '../utils/constants';
 import { ActionButton, SurfaceCard } from './ui';
+import { trackEvent } from '../analytics';
 
 /** How long (ms) the form stays locked after the wallet signs a transaction.
  *  Long enough to outlive typical mempool propagation; short enough that a
@@ -58,7 +59,17 @@ export function HabitForm() {
 
     try {
       const stakeAmount = toMicroSTX(stakeNum);
+      trackEvent('habit_create_submitted', {
+        habitNameLength: trimmedName.length,
+        stakeAmountMicroStx: stakeAmount,
+      });
+
       await createHabit({ name: trimmedName, stakeAmount });
+
+      trackEvent('habit_create_succeeded', {
+        habitNameLength: trimmedName.length,
+        stakeAmountMicroStx: stakeAmount,
+      });
 
       setName('');
       setStake(minStakeStx.toString());
@@ -73,6 +84,11 @@ export function HabitForm() {
       showToast('Transaction signed! Your habit will appear once confirmed on-chain.', 'success');
     } catch (err: unknown) {
       const message = getErrorMessage(err);
+      trackEvent('habit_create_failed', {
+        habitNameLength: trimmedName.length,
+        errorMessage: message,
+      });
+
       if (message === 'Transaction cancelled') {
         showToast('Transaction was cancelled.', 'error');
       } else {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { addressUrl } from '@yusufolosun/stx-utils';
 import { ThemeToggle } from './ThemeToggle';
 import { useHashRoute } from '../hooks/useHashRoute';
 import { ActionButton } from './ui';
+import { trackEvent } from '../analytics';
 
 const NAV_LINKS = [
   { href: '#dashboard', label: 'Dashboard' },
@@ -44,6 +45,8 @@ export function Header() {
   }, [mobileMenuOpen]);
 
   const handleDisconnect = async () => {
+    trackEvent('wallet_disconnect_clicked', { source: 'header' });
+
     try {
       await disconnect();
       showToast('Wallet disconnected.', 'success');

--- a/frontend/src/context/WalletContext.tsx
+++ b/frontend/src/context/WalletContext.tsx
@@ -1,6 +1,7 @@
 import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
 import { walletService } from '../services/walletService';
 import { WalletState } from '../types/habit';
+import { trackEvent, toWalletAddressHash } from '../analytics';
 
 interface WalletContextType {
   walletState: WalletState;
@@ -82,6 +83,7 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
 
   const connect = () => {
     setIsLoading(true);
+    trackEvent('wallet_connect_started', { source: 'header' });
     try {
       walletService.connect(
         (_payload) => {
@@ -94,10 +96,14 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
           if (address) {
             void fetchAndSetBalance(address);
           }
+          trackEvent('wallet_connected', {
+            walletAddressHash: toWalletAddressHash(address),
+          });
           setIsLoading(false);
         },
         () => {
           // User cancelled the wallet picker
+          trackEvent('wallet_connect_cancelled');
           setIsLoading(false);
         }
       );
@@ -113,6 +119,9 @@ export const WalletProvider: React.FC<WalletProviderProps> = ({ children }) => {
 
     try {
       walletService.disconnect();
+      trackEvent('wallet_disconnected', {
+        walletAddressHash: toWalletAddressHash(walletState.address),
+      });
       setWalletState({
         isConnected: false,
         address: null,

--- a/frontend/src/hooks/useHabits.ts
+++ b/frontend/src/hooks/useHabits.ts
@@ -9,6 +9,7 @@ import {
 import { POLLING_INTERVAL, CACHE_TIME, POOL_CACHE_TIME } from '../utils/constants';
 import { getHabitSyncTargets } from './habitTransactionSync';
 import { queryKeys } from '../utils/queryKeys';
+import { trackEvent } from '../analytics';
 
 export interface DailyCheckInEntry {
   habitId: number;
@@ -320,6 +321,10 @@ export const useHabits = () => {
       };
     }
 
+    trackEvent('daily_check_in_started', {
+      attempted: habitIds.length,
+    });
+
     setIsRunningDailyCheckIn(true);
     const entries: DailyCheckInEntry[] = [];
 
@@ -345,6 +350,12 @@ export const useHabits = () => {
 
     const submitted = entries.filter((entry) => entry.txId).length;
     const failed = entries.length - submitted;
+
+    trackEvent('daily_check_in_completed', {
+      attempted: entries.length,
+      submitted,
+      failed,
+    });
 
     return {
       attempted: entries.length,

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -7,6 +7,9 @@ interface ImportMetaEnv {
 	readonly VITE_CONTRACT_ADDRESS?: string;
 	readonly VITE_CONTRACT_NAME?: string;
 	readonly VITE_APP_URL?: string;
+	readonly VITE_ANALYTICS_ENABLED?: 'true' | 'false';
+	readonly VITE_ANALYTICS_ENDPOINT?: string;
+	readonly VITE_ANALYTICS_WRITE_KEY?: string;
 }
 
 interface ImportMeta {

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -92,5 +92,10 @@ Runtime configuration is sourced from Expo public env vars first, then `app.json
 - `EXPO_PUBLIC_CONTRACT_NAME`
 - `EXPO_PUBLIC_HIRO_API_BASE_URL`
 - `EXPO_PUBLIC_STACKS_NETWORK`
+- `EXPO_PUBLIC_ANALYTICS_ENABLED`
+- `EXPO_PUBLIC_ANALYTICS_ENDPOINT`
+- `EXPO_PUBLIC_ANALYTICS_WRITE_KEY`
 
 Defaults target mainnet AhhbitTracker contract values.
+
+Mobile analytics emits typed product events for app lifecycle, navigation, tracked address updates, preview generation, wallet transaction outcomes, account explorer usage, and notification setting changes.

--- a/mobile/app.config.ts
+++ b/mobile/app.config.ts
@@ -165,6 +165,9 @@ const config: ExpoConfig = {
     contractName: networkConfig.contract.contractName,
     hiroApiBaseUrl: networkConfig.hiroApiBaseUrl,
     stacksNetwork: networkConfig.networkMode,
+    analyticsEnabled: process.env.EXPO_PUBLIC_ANALYTICS_ENABLED,
+    analyticsEndpoint: process.env.EXPO_PUBLIC_ANALYTICS_ENDPOINT,
+    analyticsWriteKey: process.env.EXPO_PUBLIC_ANALYTICS_WRITE_KEY,
   },
   web: {
     favicon: './assets/favicon.png',

--- a/mobile/src/analytics/events.ts
+++ b/mobile/src/analytics/events.ts
@@ -1,0 +1,21 @@
+export type MobileAnalyticsEventName =
+  | 'app_loaded'
+  | 'route_viewed'
+  | 'address_saved'
+  | 'address_cleared'
+  | 'preview_generated'
+  | 'explorer_opened'
+  | 'notifications_toggled'
+  | 'notification_history_cleared'
+  | 'wallet_tx_confirmed'
+  | 'wallet_tx_failed';
+
+export interface MobileAnalyticsPayload {
+  route?: string;
+  source?: string;
+  walletAddressHash?: string;
+  habitId?: number;
+  functionName?: string | null;
+  state?: string;
+  errorMessage?: string;
+}

--- a/mobile/src/analytics/index.ts
+++ b/mobile/src/analytics/index.ts
@@ -1,0 +1,90 @@
+import { networkConfig } from '@/core/config';
+import type { MobileAnalyticsEventName, MobileAnalyticsPayload } from './events';
+import { anonymizeAddress, sanitizePayload } from './privacy';
+
+interface MobileAnalyticsEnvelope {
+  event: MobileAnalyticsEventName;
+  payload?: MobileAnalyticsPayload;
+  timestamp: string;
+  platform: 'mobile';
+  stage: string;
+  sessionId: string;
+}
+
+const ANALYTICS_ENDPOINT = process.env.EXPO_PUBLIC_ANALYTICS_ENDPOINT?.trim();
+const ANALYTICS_WRITE_KEY = process.env.EXPO_PUBLIC_ANALYTICS_WRITE_KEY?.trim();
+const ANALYTICS_ENABLED = process.env.EXPO_PUBLIC_ANALYTICS_ENABLED !== 'false';
+const FLUSH_INTERVAL_MS = 5_000;
+const MAX_QUEUE_SIZE = 100;
+const sessionId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+const queue: MobileAnalyticsEnvelope[] = [];
+let flushIntervalHandle: ReturnType<typeof setInterval> | null = null;
+let isFlushing = false;
+
+function canSend(): boolean {
+  return ANALYTICS_ENABLED && Boolean(ANALYTICS_ENDPOINT);
+}
+
+async function flushAnalyticsQueue(): Promise<void> {
+  if (!canSend() || !queue.length || isFlushing) {
+    return;
+  }
+
+  isFlushing = true;
+  const batch = queue.splice(0, queue.length);
+
+  try {
+    await fetch(ANALYTICS_ENDPOINT!, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        ...(ANALYTICS_WRITE_KEY ? { 'X-Analytics-Key': ANALYTICS_WRITE_KEY } : {}),
+      },
+      body: JSON.stringify({
+        app: 'ahhbittracker-mobile',
+        events: batch,
+      }),
+    });
+  } catch {
+    queue.unshift(...batch.slice(0, MAX_QUEUE_SIZE));
+  } finally {
+    isFlushing = false;
+  }
+}
+
+function startAnalyticsFlushTimer(): void {
+  if (flushIntervalHandle !== null) {
+    return;
+  }
+
+  flushIntervalHandle = setInterval(() => {
+    void flushAnalyticsQueue();
+  }, FLUSH_INTERVAL_MS);
+}
+
+startAnalyticsFlushTimer();
+
+export function trackMobileEvent(event: MobileAnalyticsEventName, payload?: MobileAnalyticsPayload): void {
+  const sanitizedPayload = sanitizePayload(payload);
+
+  queue.push({
+    event,
+    payload: sanitizedPayload,
+    timestamp: new Date().toISOString(),
+    platform: 'mobile',
+    stage: networkConfig.appStage,
+    sessionId,
+  });
+
+  if (queue.length > MAX_QUEUE_SIZE) {
+    queue.splice(0, queue.length - MAX_QUEUE_SIZE);
+  }
+}
+
+export function toWalletAddressHash(address: string | null | undefined): string | undefined {
+  return anonymizeAddress(address);
+}
+
+export async function flushMobileAnalytics(): Promise<void> {
+  await flushAnalyticsQueue();
+}

--- a/mobile/src/analytics/index.ts
+++ b/mobile/src/analytics/index.ts
@@ -1,4 +1,4 @@
-import { networkConfig } from '@/core/config';
+import { analyticsRuntimeConfig, networkConfig } from '@/core/config';
 import type { MobileAnalyticsEventName, MobileAnalyticsPayload } from './events';
 import { anonymizeAddress, sanitizePayload } from './privacy';
 
@@ -11,9 +11,9 @@ interface MobileAnalyticsEnvelope {
   sessionId: string;
 }
 
-const ANALYTICS_ENDPOINT = process.env.EXPO_PUBLIC_ANALYTICS_ENDPOINT?.trim();
-const ANALYTICS_WRITE_KEY = process.env.EXPO_PUBLIC_ANALYTICS_WRITE_KEY?.trim();
-const ANALYTICS_ENABLED = process.env.EXPO_PUBLIC_ANALYTICS_ENABLED !== 'false';
+const ANALYTICS_ENDPOINT = analyticsRuntimeConfig.endpoint?.trim();
+const ANALYTICS_WRITE_KEY = analyticsRuntimeConfig.writeKey?.trim();
+const ANALYTICS_ENABLED = analyticsRuntimeConfig.enabled;
 const FLUSH_INTERVAL_MS = 5_000;
 const MAX_QUEUE_SIZE = 100;
 const sessionId = `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;

--- a/mobile/src/analytics/privacy.ts
+++ b/mobile/src/analytics/privacy.ts
@@ -1,0 +1,33 @@
+import type { MobileAnalyticsPayload } from './events';
+
+function stableHash(input: string): string {
+  let hash = 5381;
+
+  for (let index = 0; index < input.length; index += 1) {
+    hash = (hash * 33) ^ input.charCodeAt(index);
+  }
+
+  return (hash >>> 0).toString(16).padStart(8, '0');
+}
+
+export function anonymizeAddress(address: string | null | undefined): string | undefined {
+  if (!address) {
+    return undefined;
+  }
+
+  return stableHash(address.toLowerCase());
+}
+
+export function sanitizePayload(payload?: MobileAnalyticsPayload): MobileAnalyticsPayload | undefined {
+  if (!payload) {
+    return undefined;
+  }
+
+  return {
+    ...payload,
+    errorMessage:
+      payload.errorMessage && payload.errorMessage.length > 160
+        ? `${payload.errorMessage.slice(0, 157)}...`
+        : payload.errorMessage,
+  };
+}

--- a/mobile/src/app/AppRoot.tsx
+++ b/mobile/src/app/AppRoot.tsx
@@ -1,8 +1,11 @@
+import { useEffect, useRef } from 'react';
+import { AppState } from 'react-native';
 import { StatusBar } from 'expo-status-bar';
 import { AppNavigation } from '@/app/navigation';
 import { AppProviders } from '@/app/providers';
 import { useWalletDeepLinking, useWalletInteractionSync } from '@/features/wallet';
 import { useNotificationBootstrap } from '@/features/notifications';
+import { flushMobileAnalytics, trackMobileEvent } from '@/analytics';
 
 function WalletDeepLinkBootstrap() {
   useWalletDeepLinking();
@@ -18,6 +21,29 @@ function NotificationBootstrap() {
 }
 
 export function AppRoot() {
+  const trackedAppLoadRef = useRef(false);
+
+  useEffect(() => {
+    if (trackedAppLoadRef.current) {
+      return;
+    }
+
+    trackedAppLoadRef.current = true;
+    trackMobileEvent('app_loaded', { source: 'mobile' });
+  }, []);
+
+  useEffect(() => {
+    const subscription = AppState.addEventListener('change', (nextState) => {
+      if (nextState !== 'active') {
+        void flushMobileAnalytics();
+      }
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, []);
+
   return (
     <AppProviders>
       <WalletDeepLinkBootstrap />

--- a/mobile/src/app/navigation/AppNavigation.tsx
+++ b/mobile/src/app/navigation/AppNavigation.tsx
@@ -3,11 +3,12 @@ import { NavigationContainer, useNavigationContainerRef } from '@react-navigatio
 import { RootNavigator } from './RootNavigator';
 import { linkingConfig } from './linking';
 import { navigationTheme } from './theme';
+import type { RootStackParamList } from './types';
 import { trackMobileEvent } from '@/analytics';
 
 export function AppNavigation() {
   const previousRouteRef = useRef<string | undefined>(undefined);
-  const navigationRef = useNavigationContainerRef();
+  const navigationRef = useNavigationContainerRef<RootStackParamList>();
 
   return (
     <NavigationContainer

--- a/mobile/src/app/navigation/AppNavigation.tsx
+++ b/mobile/src/app/navigation/AppNavigation.tsx
@@ -1,11 +1,33 @@
-import { NavigationContainer } from '@react-navigation/native';
+import { useRef } from 'react';
+import { NavigationContainer, useNavigationContainerRef } from '@react-navigation/native';
 import { RootNavigator } from './RootNavigator';
 import { linkingConfig } from './linking';
 import { navigationTheme } from './theme';
+import { trackMobileEvent } from '@/analytics';
 
 export function AppNavigation() {
+  const previousRouteRef = useRef<string | undefined>(undefined);
+  const navigationRef = useNavigationContainerRef();
+
   return (
-    <NavigationContainer linking={linkingConfig} theme={navigationTheme}>
+    <NavigationContainer
+      ref={navigationRef}
+      linking={linkingConfig}
+      theme={navigationTheme}
+      onReady={() => {
+        const currentRoute = navigationRef.getCurrentRoute()?.name;
+        previousRouteRef.current = currentRoute;
+        trackMobileEvent('route_viewed', { route: currentRoute, source: 'navigation_ready' });
+      }}
+      onStateChange={() => {
+        const nextRoute = navigationRef.getCurrentRoute()?.name;
+
+        if (nextRoute && nextRoute !== previousRouteRef.current) {
+          trackMobileEvent('route_viewed', { route: nextRoute, source: 'navigation_change' });
+          previousRouteRef.current = nextRoute;
+        }
+      }}
+    >
       <RootNavigator />
     </NavigationContainer>
   );

--- a/mobile/src/app/screens/AccountScreen.tsx
+++ b/mobile/src/app/screens/AccountScreen.tsx
@@ -7,6 +7,7 @@ import { useInteractionStatus } from '@/shared/hooks/useInteractionStatus';
 import { useProtectedAction } from '@/shared/hooks/useProtectedAction';
 import { formatAddress } from '@/shared/utils';
 import { spacing } from '@/shared/theme';
+import { trackMobileEvent, toWalletAddressHash } from '@/analytics';
 
 export function AccountScreen() {
   const { activeAddress, clearAddress } = useAddressState();
@@ -25,6 +26,10 @@ export function AccountScreen() {
     try {
       const explorerUrl = `https://explorer.hiro.so/address/${activeAddress}?chain=mainnet`;
       await Linking.openURL(explorerUrl);
+      trackMobileEvent('explorer_opened', {
+        source: 'account-screen',
+        walletAddressHash: toWalletAddressHash(activeAddress),
+      });
       showSuccess('Explorer opened successfully.');
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to open explorer link.';

--- a/mobile/src/app/screens/DashboardScreen.tsx
+++ b/mobile/src/app/screens/DashboardScreen.tsx
@@ -21,6 +21,7 @@ import { Card, EmptyState, LoadingState, MetricRow, Screen, SectionHeader } from
 import { useProtectedAction } from '@/shared/hooks/useProtectedAction';
 import { toMicroSTX } from '@/shared/utils';
 import { spacing } from '@/shared/theme';
+import { trackMobileEvent } from '@/analytics';
 
 export function DashboardScreen() {
   const { activeAddress, isHydrating, setAddress, clearAddress } = useAddressState();
@@ -40,24 +41,43 @@ export function DashboardScreen() {
     await runProtectedAction('create-habit', () => {
       const stakeAmountMicroStx = toMicroSTX(stakeAmountStx);
       setPreview(buildCreateHabitPreview(activeAddress, name, stakeAmountMicroStx));
+      trackMobileEvent('preview_generated', {
+        functionName: 'create-habit',
+        source: 'dashboard',
+      });
     });
   };
 
   const handleCheckInPreview = async (habitId: number) => {
     await runProtectedAction('check-in', () => {
       setPreview(buildCheckInPreview(habitId));
+      trackMobileEvent('preview_generated', {
+        functionName: 'check-in',
+        habitId,
+        source: 'dashboard',
+      });
     });
   };
 
   const handleWithdrawPreview = async (habitId: number, stakeAmount: number) => {
     await runProtectedAction('withdraw-stake', () => {
       setPreview(buildWithdrawStakePreview(habitId, stakeAmount));
+      trackMobileEvent('preview_generated', {
+        functionName: 'withdraw-stake',
+        habitId,
+        source: 'dashboard',
+      });
     });
   };
 
   const handleClaimPreview = async (habitId: number) => {
     await runProtectedAction('claim-bonus', () => {
       setPreview(buildClaimBonusPreview(habitId));
+      trackMobileEvent('preview_generated', {
+        functionName: 'claim-bonus',
+        habitId,
+        source: 'dashboard',
+      });
     });
   };
 

--- a/mobile/src/app/screens/HabitDetailsScreen.tsx
+++ b/mobile/src/app/screens/HabitDetailsScreen.tsx
@@ -22,6 +22,7 @@ import {
   getMobileCheckInWindowState,
 } from '@/shared/utils';
 import { spacing } from '@/shared/theme';
+import { trackMobileEvent } from '@/analytics';
 
 type HabitDetailsScreenProps = RootStackScreenProps<'HabitDetails'>;
 
@@ -81,6 +82,11 @@ export function HabitDetailsScreen({ route, navigation }: HabitDetailsScreenProp
 
     return runProtectedAction('check-in', () => {
       setPreview(buildCheckInPreview(habit.habitId));
+      trackMobileEvent('preview_generated', {
+        functionName: 'check-in',
+        habitId: habit.habitId,
+        source: 'habit-details',
+      });
       navigateToPreview();
     });
   };
@@ -92,6 +98,11 @@ export function HabitDetailsScreen({ route, navigation }: HabitDetailsScreenProp
 
     return runProtectedAction('withdraw-stake', () => {
       setPreview(buildWithdrawStakePreview(habit.habitId, habit.stakeAmount));
+      trackMobileEvent('preview_generated', {
+        functionName: 'withdraw-stake',
+        habitId: habit.habitId,
+        source: 'habit-details',
+      });
       navigateToPreview();
     });
   };
@@ -99,6 +110,11 @@ export function HabitDetailsScreen({ route, navigation }: HabitDetailsScreenProp
   const handleClaimPreview = () => {
     return runProtectedAction('claim-bonus', () => {
       setPreview(buildClaimBonusPreview(habit.habitId));
+      trackMobileEvent('preview_generated', {
+        functionName: 'claim-bonus',
+        habitId: habit.habitId,
+        source: 'habit-details',
+      });
       navigateToPreview();
     });
   };

--- a/mobile/src/app/screens/NotificationsScreen.tsx
+++ b/mobile/src/app/screens/NotificationsScreen.tsx
@@ -5,6 +5,7 @@ import { useNotificationCenter } from '@/features/notifications/context/Notifica
 import { ActionButton, Card, EmptyState, InteractionStatusBanner, MetricRow, Screen, SectionHeader } from '@/shared/components';
 import { useInteractionStatus } from '@/shared/hooks/useInteractionStatus';
 import { palette, spacing, typography } from '@/shared/theme';
+import { trackMobileEvent } from '@/analytics';
 
 type PendingAction = 'enable-all' | 'toggle-reminders' | 'toggle-events' | 'refresh' | 'clear' | null;
 
@@ -67,6 +68,20 @@ export function NotificationsScreen() {
 
     try {
       await callback();
+
+      if (action === 'toggle-reminders' || action === 'toggle-events') {
+        trackMobileEvent('notifications_toggled', {
+          source: 'notifications-screen',
+          state: action === 'toggle-reminders' ? String(!state.remindersEnabled) : String(!state.eventAlertsEnabled),
+        });
+      }
+
+      if (action === 'clear') {
+        trackMobileEvent('notification_history_cleared', {
+          source: 'notifications-screen',
+        });
+      }
+
       showSuccess(successMessage);
     } catch (error) {
       const message = error instanceof Error ? error.message : 'Unable to update notification settings.';

--- a/mobile/src/app/state/AppStateContext.tsx
+++ b/mobile/src/app/state/AppStateContext.tsx
@@ -18,6 +18,7 @@ import { appStateReducer, createInitialAppState } from './reducer';
 import { clearPersistedAppState, loadPersistedAppState, saveTrackedAddress } from './storage';
 import type { AppState } from './types';
 import type { ContractCallPreview } from '@/core/types';
+import { trackMobileEvent, toWalletAddressHash } from '@/analytics';
 
 interface AppStateContextValue {
   state: AppState;
@@ -106,12 +107,21 @@ export function AppStateProvider({ children }: PropsWithChildren) {
 
     await saveTrackedAddress(normalizedAddress);
     dispatch(appStateActions.setAddress(normalizedAddress));
+    trackMobileEvent('address_saved', {
+      walletAddressHash: toWalletAddressHash(normalizedAddress),
+      source: 'app-state',
+    });
   }, []);
 
   const clearTrackedAddress = useCallback(async () => {
+    const previousAddress = state.trackedAddress;
     await clearPersistedAppState();
     dispatch(appStateActions.clearAddress());
-  }, []);
+    trackMobileEvent('address_cleared', {
+      walletAddressHash: toWalletAddressHash(previousAddress),
+      source: 'app-state',
+    });
+  }, [state.trackedAddress]);
 
   const setPreview = useCallback((nextPreview: ContractCallPreview) => {
     dispatch(appStateActions.setPreview(nextPreview));

--- a/mobile/src/core/config/env.ts
+++ b/mobile/src/core/config/env.ts
@@ -7,6 +7,11 @@ function getExtra(key: 'appStage' | 'contractAddress' | 'contractName' | 'hiroAp
   return extra?.[key];
 }
 
+function getAnalyticsExtra(key: 'analyticsEnabled' | 'analyticsEndpoint' | 'analyticsWriteKey') {
+  const extra = Constants.expoConfig?.extra as Record<string, string> | undefined;
+  return extra?.[key];
+}
+
 export const networkConfig: AppNetworkConfig = Object.freeze(
   resolveMobileNetworkConfig({
     appStage: process.env.EXPO_PUBLIC_APP_STAGE ?? getExtra('appStage'),
@@ -16,3 +21,11 @@ export const networkConfig: AppNetworkConfig = Object.freeze(
     contractName: process.env.EXPO_PUBLIC_CONTRACT_NAME ?? getExtra('contractName'),
   }),
 );
+
+export const analyticsRuntimeConfig = Object.freeze({
+  enabled:
+    (process.env.EXPO_PUBLIC_ANALYTICS_ENABLED ?? getAnalyticsExtra('analyticsEnabled') ?? 'true') !==
+    'false',
+  endpoint: process.env.EXPO_PUBLIC_ANALYTICS_ENDPOINT ?? getAnalyticsExtra('analyticsEndpoint'),
+  writeKey: process.env.EXPO_PUBLIC_ANALYTICS_WRITE_KEY ?? getAnalyticsExtra('analyticsWriteKey'),
+});

--- a/mobile/src/features/wallet/useWalletInteractionSync.ts
+++ b/mobile/src/features/wallet/useWalletInteractionSync.ts
@@ -15,6 +15,7 @@ import {
   fetchWalletTransactionStatus,
   getWalletInteractionSyncTargets,
 } from './transactionSync';
+import { trackMobileEvent } from '@/analytics';
 
 const TX_POLL_INTERVAL_MS = 15_000;
 const TX_POLL_TIMEOUT_MS = 30 * 60_000;
@@ -118,6 +119,10 @@ export function useWalletInteractionSync() {
 
         if (status === 'confirmed') {
           markHandled();
+          trackMobileEvent('wallet_tx_confirmed', {
+            functionName: walletInteraction.functionName,
+            source: 'wallet-sync',
+          });
           void notifyTransaction('confirmed').catch(() => undefined);
           invalidateQueries();
           return;
@@ -125,6 +130,10 @@ export function useWalletInteractionSync() {
 
         if (status === 'failed') {
           markHandled();
+          trackMobileEvent('wallet_tx_failed', {
+            functionName: walletInteraction.functionName,
+            source: 'wallet-sync',
+          });
           void notifyTransaction('failed').catch(() => undefined);
           return;
         }

--- a/tests/mobile-analytics-privacy.test.ts
+++ b/tests/mobile-analytics-privacy.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { anonymizeAddress, sanitizePayload } from '../mobile/src/analytics/privacy';
+
+describe('mobile analytics privacy', () => {
+  it('hashes addresses deterministically', () => {
+    const address = 'SP1N3809W9CBWWX04KN3TCQHP8A9GN520BD4JMP8Z';
+    const first = anonymizeAddress(address);
+    const second = anonymizeAddress(address);
+
+    expect(first).toBeDefined();
+    expect(first).toBe(second);
+    expect(first).not.toContain('SP1N3809');
+  });
+
+  it('truncates long error payloads', () => {
+    const payload = sanitizePayload({
+      errorMessage: 'y'.repeat(400),
+      source: 'unit-test',
+    });
+
+    expect(payload?.source).toBe('unit-test');
+    expect(payload?.errorMessage?.length).toBeLessThanOrEqual(160);
+  });
+});


### PR DESCRIPTION
## Summary
- add a typed analytics event model and privacy-safe payload handling for frontend and mobile
- instrument key user journeys (app load, route views, wallet lifecycle, habit actions, preview generation, notification controls, wallet tx outcomes)
- add runtime analytics configuration for Vite and Expo environments with optional endpoint/key wiring\n- document analytics architecture and configuration in project docs

## Validation
- npm test
- cd frontend && npm test
- cd mobile && npm run check