### PR TITLE
Add end-to-end coverage for critical habit flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,11 @@ cd frontend && npm test   # Run frontend tests (30 tests)
 clarinet check        # Validate Clarity syntax
 ```
 
+Critical user-flow coverage lives alongside the test suites:
+
+- Contract E2E flows: `tests/*.e2e.test.ts`
+- Frontend E2E flows: `frontend/src/__tests__/*` (daily check-ins, withdraws, claims)
+
 ### Environment Stages
 
 The repository now supports three explicit runtime stages without committing secrets:

--- a/frontend/src/__tests__/DailyCheckInPanel.test.tsx
+++ b/frontend/src/__tests__/DailyCheckInPanel.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DailyCheckInPanel } from '../components/DailyCheckInPanel';
+import type { Habit } from '../types/habit';
+
+const baseHabit: Habit = {
+  habitId: 1,
+  name: 'Morning Run',
+  owner: 'SP2ABC123',
+  stakeAmount: 1_000_000,
+  lastCheckInBlock: 80,
+  createdAtBlock: 50,
+  currentStreak: 4,
+  isActive: true,
+  isCompleted: false,
+  bonusClaimed: false,
+};
+
+describe('DailyCheckInPanel', () => {
+  it('disables the action when no habits are eligible', () => {
+    const notify = vi.fn();
+    const runDailyCheckIn = vi.fn();
+    const habit = { ...baseHabit, lastCheckInBlock: 190 };
+
+    render(
+      <DailyCheckInPanel
+        habits={[habit]}
+        currentBlock={200}
+        isRunningDailyCheckIn={false}
+        runDailyCheckIn={runDailyCheckIn}
+        notify={notify}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Run Daily Check-In' })).toBeDisabled();
+    expect(runDailyCheckIn).not.toHaveBeenCalled();
+    expect(notify).not.toHaveBeenCalled();
+  });
+
+  it('submits eligible habits and reports success and failure', async () => {
+    const notify = vi.fn();
+    const runDailyCheckIn = vi.fn().mockResolvedValue({
+      attempted: 2,
+      submitted: 1,
+      failed: 1,
+      entries: [
+        { habitId: 1, txId: 'tx-1' },
+        { habitId: 2, error: 'Network error' },
+      ],
+    });
+
+    const habits = [
+      { ...baseHabit, habitId: 1, lastCheckInBlock: 70 },
+      { ...baseHabit, habitId: 2, lastCheckInBlock: 60 },
+    ];
+
+    render(
+      <DailyCheckInPanel
+        habits={habits}
+        currentBlock={200}
+        isRunningDailyCheckIn={false}
+        runDailyCheckIn={runDailyCheckIn}
+        notify={notify}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Run Daily Check-In' }));
+
+    await waitFor(() => {
+      expect(runDailyCheckIn).toHaveBeenCalledWith([1, 2]);
+    });
+
+    expect(notify).toHaveBeenCalledWith('Submitted 1 check-in transaction(s).', 'success');
+    expect(notify).toHaveBeenCalledWith('1 check-in(s) failed. Network error', 'error');
+  });
+});

--- a/frontend/src/__tests__/HabitCard.claim-slash.test.tsx
+++ b/frontend/src/__tests__/HabitCard.claim-slash.test.tsx
@@ -1,0 +1,124 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { HabitCard } from '../components/HabitCard';
+import type { Habit } from '../types/habit';
+
+const claimBonus = vi.fn().mockResolvedValue('tx-claim');
+const slashHabit = vi.fn().mockResolvedValue('tx-slash');
+const showToast = vi.fn();
+
+let walletAddress = 'SP2ABC123';
+
+vi.mock('../analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('../hooks/useHabits', () => ({
+  useHabits: () => ({
+    checkIn: vi.fn(),
+    withdrawStake: vi.fn(),
+    claimBonus,
+    slashHabit,
+    estimatedBonusShare: 500_000,
+    unclaimedCompletedHabits: 1,
+    pendingCheckIns: new Set<number>(),
+    pendingWithdrawals: new Set<number>(),
+    pendingClaims: new Set<number>(),
+    pendingSlashes: new Set<number>(),
+  }),
+}));
+
+vi.mock('../context/ToastContext', () => ({
+  useToast: () => ({
+    showToast,
+  }),
+}));
+
+vi.mock('../context/WalletContext', () => ({
+  useWallet: () => ({
+    walletState: {
+      isConnected: true,
+      address: walletAddress,
+      balance: 10_000_000,
+    },
+  }),
+}));
+
+vi.mock('../hooks/useCurrentBlock', () => ({
+  useCurrentBlock: () => 200,
+}));
+
+vi.mock('../utils/formatting', () => ({
+  formatSTX: (v: number) => (v / 1_000_000).toFixed(2),
+  blocksAgo: () => '10 blocks ago',
+  blocksToTime: () => '~2h',
+}));
+
+const completedHabit: Habit = {
+  habitId: 3,
+  name: 'Claim Bonus',
+  owner: 'SP2ABC123',
+  stakeAmount: 1_000_000,
+  lastCheckInBlock: 120,
+  createdAtBlock: 50,
+  currentStreak: 9,
+  isActive: false,
+  isCompleted: true,
+  bonusClaimed: false,
+};
+
+const expiredHabit: Habit = {
+  habitId: 4,
+  name: 'Expired Habit',
+  owner: 'SP2ABC123',
+  stakeAmount: 500_000,
+  lastCheckInBlock: 10,
+  createdAtBlock: 5,
+  currentStreak: 2,
+  isActive: true,
+  isCompleted: false,
+  bonusClaimed: false,
+};
+
+describe('HabitCard claim and slash flows', () => {
+  beforeEach(() => {
+    claimBonus.mockClear();
+    slashHabit.mockClear();
+    showToast.mockClear();
+    walletAddress = 'SP2ABC123';
+  });
+
+  it('confirms and submits a bonus claim', async () => {
+    render(<HabitCard habit={completedHabit} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Claim Bonus' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Claim' }));
+
+    await waitFor(() => {
+      expect(claimBonus).toHaveBeenCalledWith(completedHabit.habitId);
+    });
+
+    expect(showToast).toHaveBeenCalledWith(
+      'Bonus claim signed! It will arrive once confirmed on-chain.',
+      'success',
+    );
+  });
+
+  it('confirms and submits a slash when viewing another wallet', async () => {
+    walletAddress = 'SP9DIFFERENT';
+
+    render(<HabitCard habit={expiredHabit} />);
+
+    fireEvent.click(screen.getByText('Finalize Expired Habit'));
+    fireEvent.click(screen.getByRole('button', { name: 'Finalize' }));
+
+    await waitFor(() => {
+      expect(slashHabit).toHaveBeenCalledWith(expiredHabit.habitId);
+    });
+
+    expect(showToast).toHaveBeenCalledWith(
+      'Habit finalized! Stake will be moved to the pool once confirmed on-chain.',
+      'success',
+    );
+  });
+});

--- a/frontend/src/__tests__/HabitCard.withdraw.test.tsx
+++ b/frontend/src/__tests__/HabitCard.withdraw.test.tsx
@@ -1,0 +1,86 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { HabitCard } from '../components/HabitCard';
+import type { Habit } from '../types/habit';
+
+const withdrawStake = vi.fn().mockResolvedValue('tx-withdraw');
+const showToast = vi.fn();
+
+vi.mock('../analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('../hooks/useHabits', () => ({
+  useHabits: () => ({
+    checkIn: vi.fn(),
+    withdrawStake,
+    claimBonus: vi.fn(),
+    slashHabit: vi.fn(),
+    estimatedBonusShare: 0,
+    unclaimedCompletedHabits: 0,
+    pendingCheckIns: new Set<number>(),
+    pendingWithdrawals: new Set<number>(),
+    pendingClaims: new Set<number>(),
+    pendingSlashes: new Set<number>(),
+  }),
+}));
+
+vi.mock('../context/ToastContext', () => ({
+  useToast: () => ({
+    showToast,
+  }),
+}));
+
+vi.mock('../context/WalletContext', () => ({
+  useWallet: () => ({
+    walletState: {
+      isConnected: true,
+      address: 'SP2ABC123',
+      balance: 10_000_000,
+    },
+  }),
+}));
+
+vi.mock('../hooks/useCurrentBlock', () => ({
+  useCurrentBlock: () => 200,
+}));
+
+vi.mock('../utils/formatting', () => ({
+  formatSTX: (v: number) => (v / 1_000_000).toFixed(2),
+  blocksAgo: () => '10 blocks ago',
+  blocksToTime: () => '~2h',
+}));
+
+const habit: Habit = {
+  habitId: 7,
+  name: 'Withdraw Ready',
+  owner: 'SP2ABC123',
+  stakeAmount: 1_000_000,
+  lastCheckInBlock: 70,
+  createdAtBlock: 50,
+  currentStreak: 7,
+  isActive: true,
+  isCompleted: false,
+  bonusClaimed: false,
+};
+
+describe('HabitCard withdraw flow', () => {
+  it('confirms and submits a withdrawal', async () => {
+    render(<HabitCard habit={habit} />);
+
+    fireEvent.click(screen.getByText('Withdraw Stake'));
+    fireEvent.click(screen.getByRole('button', { name: 'Withdraw' }));
+
+    await waitFor(() => {
+      expect(withdrawStake).toHaveBeenCalledWith({
+        habitId: habit.habitId,
+        stakeAmount: habit.stakeAmount,
+      });
+    });
+
+    expect(showToast).toHaveBeenCalledWith(
+      'Withdrawal signed! Your STX will return once confirmed on-chain.',
+      'success',
+    );
+  });
+});

--- a/frontend/src/__tests__/HabitForm.test.tsx
+++ b/frontend/src/__tests__/HabitForm.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { HabitForm } from '../components/HabitForm';
 import { MAX_HABIT_NAME_LENGTH, MAX_STAKE_AMOUNT, MIN_STAKE_AMOUNT } from '../utils/constants';
 
@@ -81,5 +81,39 @@ describe('HabitForm', () => {
     expect(await screen.findByText('Maximum stake is 100 STX')).toBeDefined();
     expect(createHabit).not.toHaveBeenCalled();
     expect(showToast).not.toHaveBeenCalled();
+  });
+
+  it('locks the form after signing and unlocks after the cooldown', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'));
+    render(<HabitForm />);
+
+    fireEvent.change(screen.getByLabelText('Habit Name'), {
+      target: { value: 'Daily Exercise' },
+    });
+    fireEvent.change(screen.getByLabelText('Stake Amount (STX)'), {
+      target: { value: '0.5' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Create Habit' }));
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(createHabit).toHaveBeenCalledTimes(1);
+    expect(screen.getByRole('button', { name: /Waiting for confirmation/ })).toBeDisabled();
+
+    act(() => {
+      vi.advanceTimersByTime(45_000);
+    });
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole('button', { name: 'Create Habit' })).toBeEnabled();
+
+    vi.useRealTimers();
   });
 });

--- a/frontend/src/__tests__/testProviders.tsx
+++ b/frontend/src/__tests__/testProviders.tsx
@@ -1,0 +1,18 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+}
+
+export function createQueryWrapper(client: QueryClient) {
+  return function QueryWrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}

--- a/frontend/src/__tests__/useHabits.dailyCheckIn.test.tsx
+++ b/frontend/src/__tests__/useHabits.dailyCheckIn.test.tsx
@@ -1,0 +1,78 @@
+import { renderHook, act } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHabits } from '../hooks/useHabits';
+import { createQueryWrapper, createTestQueryClient } from './testProviders';
+
+const mockRefreshBalance = vi.fn();
+const mockAddTransaction = vi.fn();
+const { checkIn } = vi.hoisted(() => ({ checkIn: vi.fn() }));
+
+vi.mock('../analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('../context/WalletContext', () => ({
+  useWallet: () => ({
+    walletState: {
+      isConnected: true,
+      address: 'SP2ABC123',
+      balance: 10_000_000,
+    },
+    refreshBalance: mockRefreshBalance,
+  }),
+}));
+
+vi.mock('../context/TransactionContext', () => ({
+  useTransactions: () => ({
+    addTransaction: mockAddTransaction,
+    transactions: [],
+  }),
+}));
+
+vi.mock('../services/contractService', () => ({
+  contractService: {
+    readUserHabits: vi.fn().mockResolvedValue([]),
+    readHabit: vi.fn(),
+    readUserStats: vi.fn().mockResolvedValue({ totalHabits: 0, habitIds: [] }),
+    readPoolBalance: vi.fn().mockResolvedValue(0),
+    readEstimatedBonusShare: vi.fn().mockResolvedValue(0),
+    readUnclaimedCompletedHabits: vi.fn().mockResolvedValue(0),
+    invalidateAddressReadCache: vi.fn(),
+    invalidatePoolReadCache: vi.fn(),
+    createHabit: vi.fn(),
+    checkIn,
+    withdrawStake: vi.fn(),
+    claimBonus: vi.fn(),
+    slashHabit: vi.fn(),
+  },
+}));
+
+describe('useHabits runDailyCheckIn', () => {
+  beforeEach(() => {
+    checkIn.mockReset();
+    mockAddTransaction.mockReset();
+    mockRefreshBalance.mockReset();
+  });
+
+  it('stops queueing when a user cancels a check-in', async () => {
+    checkIn
+      .mockResolvedValueOnce('tx-1')
+      .mockRejectedValueOnce(new Error('Transaction cancelled'))
+      .mockResolvedValueOnce('tx-2');
+
+    const queryClient = createTestQueryClient();
+    const wrapper = createQueryWrapper(queryClient);
+    const { result } = renderHook(() => useHabits(), { wrapper });
+
+    let response;
+    await act(async () => {
+      response = await result.current.runDailyCheckIn([1, 2, 3]);
+    });
+
+    expect(response?.attempted).toBe(2);
+    expect(response?.submitted).toBe(1);
+    expect(response?.failed).toBe(1);
+    expect(checkIn).toHaveBeenCalledTimes(2);
+    expect(mockAddTransaction).toHaveBeenCalledWith('tx-1', 'check-in');
+  });
+});

--- a/tests/bonus-claim.e2e.test.ts
+++ b/tests/bonus-claim.e2e.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+import {
+  buildStreak,
+  createHabit,
+  mineBlocks,
+  readOkUint,
+  slashHabit,
+  withdrawStake,
+} from "./helpers/habit-flow";
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get("deployer")!;
+const user1 = accounts.get("wallet_1")!;
+const user2 = accounts.get("wallet_2")!;
+const user3 = accounts.get("wallet_3")!;
+
+const MIN_STAKE = 20_000;
+
+describe("bonus claim e2e", () => {
+  it("funds the pool and splits bonuses across claimants", () => {
+    const failing = createHabit(user3, "Pool Source", MIN_STAKE * 3);
+    const failingId = readOkUint(failing);
+    buildStreak(user3, failingId, 1);
+
+    mineBlocks(150);
+    const slash = slashHabit(user2, failingId);
+    expect(slash.result).toBeOk(Cl.bool(true));
+
+    const habit1 = createHabit(user1, "Habit A", MIN_STAKE);
+    const habit1Id = readOkUint(habit1);
+    buildStreak(user1, habit1Id, 7);
+    const withdrawal1 = withdrawStake(user1, habit1Id);
+    expect(withdrawal1.result).toBeOk(Cl.uint(MIN_STAKE));
+
+    const habit2 = createHabit(user2, "Habit B", MIN_STAKE);
+    const habit2Id = readOkUint(habit2);
+    buildStreak(user2, habit2Id, 7);
+    const withdrawal2 = withdrawStake(user2, habit2Id);
+    expect(withdrawal2.result).toBeOk(Cl.uint(MIN_STAKE));
+
+    const unclaimed = simnet.callReadOnlyFn(
+      "habit-tracker-v2",
+      "get-unclaimed-completed-habits",
+      [],
+      deployer,
+    );
+    expect(unclaimed.result).toBeOk(Cl.uint(2));
+
+    const pool = simnet.callReadOnlyFn(
+      "habit-tracker-v2",
+      "get-pool-balance",
+      [],
+      deployer,
+    );
+    expect(pool.result).toBeOk(Cl.uint(MIN_STAKE * 3));
+
+    const claim1 = simnet.callPublicFn(
+      "habit-tracker-v2",
+      "claim-bonus",
+      [Cl.uint(habit1Id)],
+      user1,
+    );
+    const claim1Amount = readOkUint(claim1);
+    expect(claim1.result).toBeOk(Cl.uint(claim1Amount));
+
+    const claim2 = simnet.callPublicFn(
+      "habit-tracker-v2",
+      "claim-bonus",
+      [Cl.uint(habit2Id)],
+      user2,
+    );
+    const claim2Amount = readOkUint(claim2);
+    expect(claim2.result).toBeOk(Cl.uint(claim2Amount));
+    expect(claim1Amount).toBe(claim2Amount);
+
+    const poolAfter = simnet.callReadOnlyFn(
+      "habit-tracker-v2",
+      "get-pool-balance",
+      [],
+      deployer,
+    );
+    expect(poolAfter.result).toBeOk(Cl.uint(0));
+
+    const unclaimedAfter = simnet.callReadOnlyFn(
+      "habit-tracker-v2",
+      "get-unclaimed-completed-habits",
+      [],
+      deployer,
+    );
+    expect(unclaimedAfter.result).toBeOk(Cl.uint(0));
+  });
+});

--- a/tests/expired-habit.e2e.test.ts
+++ b/tests/expired-habit.e2e.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+import {
+  buildStreak,
+  checkIn,
+  createHabit,
+  mineBlocks,
+  readOkUint,
+  slashHabit,
+} from "./helpers/habit-flow";
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get("deployer")!;
+const user1 = accounts.get("wallet_1")!;
+const user2 = accounts.get("wallet_2")!;
+
+const MIN_STAKE = 20_000;
+
+describe("expired habit e2e", () => {
+  it("slashes an expired habit and moves stake to pool", () => {
+    const created = createHabit(user1, "Expire Me", MIN_STAKE);
+    const habitId = readOkUint(created);
+
+    buildStreak(user1, habitId, 1);
+    mineBlocks(150);
+
+    const slash = slashHabit(user2, habitId);
+    expect(slash.result).toBeOk(Cl.bool(true));
+
+    const pool = simnet.callReadOnlyFn(
+      "habit-tracker-v2",
+      "get-pool-balance",
+      [],
+      deployer,
+    );
+    expect(pool.result).toBeOk(Cl.uint(MIN_STAKE));
+
+    const habit = simnet.callReadOnlyFn(
+      "habit-tracker-v2",
+      "get-habit",
+      [Cl.uint(habitId)],
+      deployer,
+    );
+    expect(habit.result).not.toBeNone();
+
+    const lateCheckIn = checkIn(user1, habitId);
+    expect(lateCheckIn.result).toBeErr(Cl.uint(108));
+  });
+});

--- a/tests/habit-lifecycle.e2e.test.ts
+++ b/tests/habit-lifecycle.e2e.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import { Cl } from "@stacks/transactions";
+import { buildStreak, createHabit, readOkUint, withdrawStake } from "./helpers/habit-flow";
+
+const accounts = simnet.getAccounts();
+const deployer = accounts.get("deployer")!;
+const user1 = accounts.get("wallet_1")!;
+
+const MIN_STAKE = 20_000;
+
+describe("habit lifecycle e2e", () => {
+  it("creates, checks in for 7 days, and withdraws stake", () => {
+    const created = createHabit(user1, "Morning Run", MIN_STAKE);
+    expect(created.result).toBeOk(Cl.uint(1));
+
+    const habitId = readOkUint(created);
+    buildStreak(user1, habitId, 7);
+
+    const withdrawal = withdrawStake(user1, habitId);
+    expect(withdrawal.result).toBeOk(Cl.uint(MIN_STAKE));
+
+    const habit = simnet.callReadOnlyFn(
+      "habit-tracker-v2",
+      "get-habit",
+      [Cl.uint(habitId)],
+      deployer,
+    );
+    expect(habit.result).not.toBeNone();
+
+    const streak = simnet.callReadOnlyFn(
+      "habit-tracker-v2",
+      "get-habit-streak",
+      [Cl.uint(habitId)],
+      deployer,
+    );
+    expect(streak.result).toBeOk(Cl.uint(7));
+
+    const unclaimed = simnet.callReadOnlyFn(
+      "habit-tracker-v2",
+      "get-unclaimed-completed-habits",
+      [],
+      deployer,
+    );
+    expect(unclaimed.result).toBeOk(Cl.uint(1));
+  });
+});

--- a/tests/helpers/habit-flow.ts
+++ b/tests/helpers/habit-flow.ts
@@ -1,0 +1,61 @@
+import { Cl } from "@stacks/transactions";
+
+const MIN_CHECK_IN_INTERVAL = 120;
+
+export function createHabit(caller: string, name: string, stake: number) {
+  return simnet.callPublicFn(
+    "habit-tracker-v2",
+    "create-habit",
+    [Cl.stringUtf8(name), Cl.uint(stake)],
+    caller,
+  );
+}
+
+export function checkIn(caller: string, habitId: number) {
+  return simnet.callPublicFn(
+    "habit-tracker-v2",
+    "check-in",
+    [Cl.uint(habitId)],
+    caller,
+  );
+}
+
+export function withdrawStake(caller: string, habitId: number) {
+  return simnet.callPublicFn(
+    "habit-tracker-v2",
+    "withdraw-stake",
+    [Cl.uint(habitId)],
+    caller,
+  );
+}
+
+export function slashHabit(caller: string, habitId: number) {
+  return simnet.callPublicFn(
+    "habit-tracker-v2",
+    "slash-habit",
+    [Cl.uint(habitId)],
+    caller,
+  );
+}
+
+export function mineToNextCheckIn(): void {
+  simnet.mineEmptyBlocks(MIN_CHECK_IN_INTERVAL);
+}
+
+export function mineBlocks(blocks: number): void {
+  simnet.mineEmptyBlocks(blocks);
+}
+
+export function buildStreak(caller: string, habitId: number, days: number) {
+  const results = [] as Array<ReturnType<typeof checkIn>>;
+  for (let i = 0; i < days; i += 1) {
+    mineToNextCheckIn();
+    results.push(checkIn(caller, habitId));
+  }
+  return results;
+}
+
+export function readOkUint(result: any): number {
+  const rawValue = result?.result?.value?.value ?? result?.result?.value ?? 0;
+  return Number(rawValue);
+}


### PR DESCRIPTION
## Summary
- add contract E2E flow tests for habit lifecycle, bonus claims, and expirations
- add frontend integration tests for daily check-ins and habit actions
- document where critical flow tests live

## Testing
- npm test
- (cd frontend && npm test)